### PR TITLE
Fix matching prefix for api routes

### DIFF
--- a/src/Routing/ApiCollection.php
+++ b/src/Routing/ApiCollection.php
@@ -87,9 +87,27 @@ class ApiCollection extends RouteCollection {
 	 */
 	protected function matchPrefix($request)
 	{
-		$path = explode('/', trim($request->getPathInfo(), '/'));
+		if ( ! $prefix = $this->option('prefix'))
+		{
+			return false;
+		}
 
-		return ($path[0] === $this->option('prefix') and $this->option('prefix'));
+		$prefix = $this->filterAndExplode($this->option('prefix'));
+
+		$path = $this->filterAndExplode($request->getPathInfo());
+
+		return $prefix == array_slice($path, 0, count($prefix));
+	}
+
+	/**
+	 * Explode array on slash and remove empty values.
+	 * 
+	 * @param  array  $array
+	 * @return array
+	 */
+	protected function filterAndExplode($array)
+	{
+		return array_filter(explode('/', $array));
 	}
 
 }

--- a/tests/RoutingRouterTest.php
+++ b/tests/RoutingRouterTest.php
@@ -63,14 +63,14 @@ class RoutingRouterTest extends PHPUnit_Framework_TestCase {
 
 	public function testPrefixOnApiRoutes()
 	{
-		$this->router->api(['version' => 'v1', 'prefix' => 'api'], function()
+		$this->router->api(['version' => 'v1', 'prefix' => 'foo/bar'], function()
 		{
 			$this->router->get('foo', function() { return 'bar'; });
 		});
 
 		$route = $this->router->getApiCollection('v1')->getRoutes()[0];
 
-		$this->assertEquals('api', $route->getAction()['prefix']);
+		$this->assertEquals('foo/bar', $route->getAction()['prefix']);
 	}
 
 	public function testRouterDispatchesInternalRequests()


### PR DESCRIPTION
Hey mate!, I've fixed the prefix it was matching anything at the start of the string and it was causing 404s on the api routes. Also made a test on it.

I hope it helps, let me know! ;)
