### PR TITLE
Determining transformable correctly for Collections

### DIFF
--- a/src/Transformer/Factory.php
+++ b/src/Transformer/Factory.php
@@ -175,6 +175,11 @@ class Factory {
 	 */
 	protected function boundByContract($class)
 	{
+		if ($this->isCollection($class))
+		{
+			return is_object($class->first()) and $class->first() instanceof TransformableInterface;
+		}
+
 		return is_object($class) and $class instanceof TransformableInterface;
 	}
 

--- a/tests/TransformerFactoryTest.php
+++ b/tests/TransformerFactoryTest.php
@@ -39,7 +39,7 @@ class TransformerTest extends PHPUnit_Framework_TestCase {
 		$this->transformerFactory->transform('Foo', 'FooTransformerStub');
 		$this->assertTrue($this->transformerFactory->transformableResponse('Foo'));
 		$this->assertTrue($this->transformerFactory->transformableResponse(new Bar));
-		$this->assertTrue($this->transformerFactory->transformableResponse(new Illuminate\Support\Collection([new Foo, new Foo])));
+		$this->assertTrue($this->transformerFactory->transformableResponse(new Illuminate\Support\Collection([new Bar, new Bar])));
 	}
 
 


### PR DESCRIPTION
It was determining a collection of Transformable objects as non-transformable. This little check assures that it determines it correctly.

Also, the test is fixed. (line 38 and 42 were contradictory to each other in `TransformerFactoryTest.php`).
