### PR TITLE
Support for Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": ">=4.1",
+        "illuminate/support": "~4.1",
         "league/fractal": "~0.7"
     },
     "require-dev": {
         "dingo/oauth2-server-laravel": "0.2.*",
         "lucadegasperi/oauth2-server-laravel": "1.0.*",
-        "illuminate/routing": ">=4.1",
-        "illuminate/events": ">=4.1",
-        "illuminate/auth": ">=4.1",
-        "illuminate/database": ">=4.1",
-        "illuminate/pagination": ">=4.1",
+        "illuminate/routing": "~4.1",
+        "illuminate/events": "~4.1",
+        "illuminate/auth": "~4.1",
+        "illuminate/database": "~4.1",
+        "illuminate/pagination": "~4.1",
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9"
     },


### PR DESCRIPTION
I just started playing with Laravel 4.2 and got a lot of issues installing this package. I have suggested the following allowing for 4.1.\* and 4.2.\* installations.

I believe this would work if not let me know of way.
