### PR TITLE
Add laravel auth provider to check already authenticated users and tests

### DIFF
--- a/src/Auth/LaravelAuthProvider.php
+++ b/src/Auth/LaravelAuthProvider.php
@@ -1,0 +1,55 @@
+<?php namespace Dingo\Api\Auth;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Auth\AuthManager;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+class LaravelAuthProvider extends AuthorizationProvider {
+
+	/**
+	 * Illuminate authentication manager.
+	 * 
+	 * @var \Illuminate\Auth\AuthManager
+	 */
+	protected $auth;
+
+	/**
+	 * Create a new instance.
+	 * 
+	 * @param  \Illuminate\Auth\AuthManager  $auth
+	 * @return void
+	 */
+	public function __construct(AuthManager $auth)
+	{
+		$this->auth = $auth;
+	}
+
+	/**
+	 * Check if user is authenticated.
+	 * 
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @return int
+	 */
+	public function authenticate(Request $request, Route $route)
+	{
+		if($this->auth->check())
+		{
+			return $this->auth->user()->id;
+		}
+		
+		throw new UnauthorizedHttpException('Laravel', 'Not authorized.');
+	}
+
+	/**
+	 * Get the providers authorization method.
+	 * 
+	 * @return string
+	 */
+	public function getAuthorizationMethod()
+	{
+		return 'laravel';
+	}
+
+}

--- a/tests/AuthLaravelProviderTest.php
+++ b/tests/AuthLaravelProviderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Dingo\Api\Auth\LaravelAuthProvider;
+
+class AuthLaravelProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp()
+	{
+		$this->auth = m::mock('Illuminate\Auth\AuthManager');
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testIsAuthenticatedAndReturnsUserId()
+	{	
+		$this->auth->shouldReceive('check')
+			->once()
+			->andReturn(true);
+
+		$this->auth->shouldReceive('user')
+			->once()
+			->andReturn((object) ['id' => 1]);
+
+
+		$request = Request::create('foo', 'GET');
+		$provider = new LaravelAuthProvider($this->auth);
+
+		$this->assertEquals(1, $provider->authenticate($request, m::mock('Illuminate\Routing\Route')));
+	}
+
+	/**
+	 * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
+	 */
+	public function testIsNotAuthenticatedThrowsException()
+	{
+		$request = Request::create('foo', 'GET');
+		$provider = new LaravelAuthProvider($this->auth);
+
+		$this->auth->shouldReceive('check')
+			->once()
+			->andReturn(false);
+
+		$provider->authenticate($request, m::mock('Illuminate\Routing\Route'));
+	}
+
+}


### PR DESCRIPTION
I'm using dingo api in an AngularJS app, so I won't authenticate users every request.

This auth provider is just to check if the user is already logged in, if not it will throw `UnauthorizedHttpException`.

Ps: Not sure what name to use, so I just called it "Laravel Provider"
