### PR TITLE
Update FractalTransformer.php

### DIFF
--- a/src/Transformer/FractalTransformer.php
+++ b/src/Transformer/FractalTransformer.php
@@ -97,7 +97,7 @@ class FractalTransformer extends Transformer {
 	{
 		$scopes = array_filter(explode($this->includeSeparator, $this->request->get($this->includeKey)));
 
-		$this->fractal->setRequestedScopes($scopes);
+		$this->fractal->parseIncludes($scopes);
 	}
 
 }


### PR DESCRIPTION
Since this package is requiring "~0.7", the 0.8 release of `league/fractal` breaks the transformations. ([Reference](https://github.com/thephpleague/fractal/blob/master/CHANGELOG.md))

The error this fixes:

``` php
Call to undefined method League\Fractal\Manager::setRequestedScopes()
```
