### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.5-dev"
+            "dev-master": "0.6-dev"
         }
     }
 }


### PR DESCRIPTION
Should the breaking changes since the 0.5 release mean we should target 0.6 now?
