### PR TITLE
Catch exceptions when checking user auth

### DIFF
--- a/src/Auth/Shield.php
+++ b/src/Auth/Shield.php
@@ -127,6 +127,16 @@ class Shield
     }
 
     /**
+	 * Get the authenticated user's ID.
+	 * 
+	 * @return int|string The user's ID, or the client ID in the case of client_credentials grant
+	 */
+	public function getUserId()
+	{
+		return $this->userId;
+	}
+
+    /**
      * Alias for getUser.
      *
      * @return \Illuminate\Auth\GenericUser|\Illuminate\Database\Eloquent\Model
@@ -135,6 +145,16 @@ class Shield
     {
         return $this->getUser();
     }
+
+    /**
+	 * Alias for getUserId.
+	 * 
+	 * @return int|string
+	 */
+	public function userId()
+	{
+		return $this->getUserId();
+	}
 
     /**
      * Set the authenticated user.

--- a/src/Facades/API.php
+++ b/src/Facades/API.php
@@ -65,6 +65,16 @@ class API extends Facade
     }
 
     /**
+	 * Get the authenticated API user's ID.
+	 *
+	 * @return int|string The user's ID, or the client_id in the case of client_credentials grant
+	 */
+	public static function userId()
+	{
+		return static::$app['dingo.api.auth']->getUserId();
+	}
+
+    /**
      * Determine if a request is internal.
      *
      * @return bool


### PR DESCRIPTION
This is an attempt to fix #56.

When using the `client_credentials` grant type, the `Shield::check()` method causes an exception to be thrown, because there is no "user" to check.

This pull requests catches exceptions in the `Shield::check()` method, and returns false instead.

This seems to work for the limited use case I'm using, although I suspect that catching all `Exception`s is not quite right, or that there's a whole part of this I'm not aware of that causes this to be stupid.
