### PR TITLE
Revert changes to the getApiRouteCollectionFromRequest()

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -287,7 +287,7 @@ class Router extends IlluminateRouter
             return $this->requestsTargettingApi[$key];
         }
 
-        $collection = $this->getApiRouteCollectionFromRequest($request) ?: $this->getDefaultApiRouteCollection();
+        $collection = $this->getApiRouteCollectionFromRequest($request);
 
         try {
             $collection->match($request);
@@ -326,9 +326,18 @@ class Router extends IlluminateRouter
      */
     public function getApiRouteCollectionFromRequest(Request $request)
     {
-        return array_first($this->api, function ($key, $collection) use ($request) {
+        $collection = array_first($this->api, function ($key, $collection) use ($request) {
             return $collection->matchesRequest($request);
         });
+
+        // If we don't initially find a collection then we'll grab the default
+        // version collection instead. This is a sort of graceful fallback
+        // and allows viewing of the latest API version in the browser.
+        if (! $collection) {
+            return $this->getDefaultApiRouteCollection();
+        }
+
+        return $collection;
     }
 
     /**


### PR DESCRIPTION
The changes which were made to this method breaks authentication if no accept header is set.

Please see https://github.com/dingo/api/issues/84

Alternatively, we would need to call getDefaultApiRouteCollection() in Authentication.php (Line 91~) if no collection is returned.
