### PR TITLE
Set dispatch to check for isSuccessful

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -336,7 +336,7 @@ class Dispatcher
         try {
             $response = $this->router->dispatch($request);
 
-            if (! $response->isOk()) {
+            if (! $response->isSuccessful()) {
                 throw new HttpException($response->getStatusCode(), $response->getOriginalContent());
             }
         } catch (HttpExceptionInterface $exception) {


### PR DESCRIPTION
This was throwing an HttpException when doing internal calls to `post`, since the response code was set to 201.  Now, anything in the 200s will be accepted. 
