### PR TITLE
Updated docblock

### DIFF
--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -259,7 +259,7 @@ class ResponseBuilder
     /**
      * Resolve the Fractal manager.
      *
-     * @return void
+     * @return \League\Fractal\Manager
      */
     protected function resolveFractal()
     {


### PR DESCRIPTION
resolveFractal returns an instance rather then void.
