### PR TITLE
resolves #125 Inject Response into ResponseFormat

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -52,6 +52,9 @@ class Response extends IlluminateResponse
 
         $formatter = static::getFormatter($format);
 
+        // Pass the current response to the formatter.
+        $formatter->setApiResponse($this);
+
         // Set the "Content-Type" header of the response to that which
         // is defined by the formatter being used. Before setting it
         // we'll get the original content type in case we need to

--- a/src/Http/ResponseFormat/ResponseFormat.php
+++ b/src/Http/ResponseFormat/ResponseFormat.php
@@ -12,6 +12,13 @@ abstract class ResponseFormat
     protected $request;
 
     /**
+     * Dingo Response instance
+     *
+     * @var \Dingo\Api\Http\Response
+     */
+    protected $apiResponse;
+
+    /**
      * Set the request intance.
      * 
      * @param  \Illuminate\Http\Request  $request
@@ -22,6 +29,29 @@ abstract class ResponseFormat
         $this->request = $request;
 
         return $this;
+    }
+
+    /**
+     * Set the response instance
+     *
+     * @param  \Dingo\Api\Http\Response  $response
+     * @return \Dingo\Api\Http\ResponseFormat\ResponseFormat
+     */
+    public function setApiResponse($response)
+    {
+        $this->apiResponse = $response;
+
+        return $this;
+    }
+
+    /**
+     * Get the response instance
+     *
+     * @return \Dingo\Api\Http\Response
+     */
+    public function getApiResponse()
+    {
+        return $this->apiResponse;
     }
 
     /**


### PR DESCRIPTION
Injecting before getContentType in case formatter wants to use existing response information to alter it (can't imagine why, but it's available).

Addresses issue #125
