### PR TITLE
show the real content, instead of 2nd time morphing without the custom f...

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -371,7 +371,7 @@ class Dispatcher
 
         $this->refreshRequestStack();
 
-        return $response->getOriginalContent();
+        return $response->getContent();
     }
 
     /**


### PR DESCRIPTION
...ormatter

https://github.com/dingo/api/issues/139

I'm not sure if it's the only place where it should be updated, but before that the content was generated fine, but during the

``` php
return $response->getOriginalContent();
```

It was returned as collection or model and then double morphed, without the custom formatters.
