### PR TITLE
[Bugfix] : Disable conditional request feature outside API and does not overwrite existing ETag

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -285,15 +285,21 @@ class Router extends IlluminateRouter
     {
         $response = parent::prepareResponse($request, $response);
 
-        if ($response instanceof IlluminateResponse && $this->requestTargettingApi($request)) {
-            $response = ApiResponse::makeFromExisting($response);
-        }
+        if ($this->requestTargettingApi($request)) {
 
-        if ($response->isSuccessful() && $this->getConditionalRequest()) {
-            $response->setEtag(md5($response->getContent()));
-        }
+            if ($response instanceof IlluminateResponse) {
+                $response = ApiResponse::makeFromExisting($response);
+            }
 
-        $response->isNotModified($request);
+            if ($response->isSuccessful() && $this->getConditionalRequest()) {
+
+                if (! $response->headers->has('ETag')) {
+                    $response->setEtag(md5($response->getContent()));
+                }
+
+                $response->isNotModified($request);
+            }
+        }
 
         return $response;
     }


### PR DESCRIPTION
Ensure the conditional request feature (setting an ETag and returning a 304) is not applied to routes outside API.
Also ensures this feature does not overwrite a custom ETag already set by the user.

Fix #141
