### PR TITLE
Call parent::isRoutable

### DIFF
--- a/src/Routing/ControllerInspector.php
+++ b/src/Routing/ControllerInspector.php
@@ -20,6 +20,6 @@ class ControllerInspector extends IlluminateControllerInspector
             return false;
         }
 
-        return parent::isRoutable($method, $controller);
+        return call_user_func_array([$this, 'parent::isRoutable'], [$method, $controller]);
     }
 }


### PR DESCRIPTION
Properly calls `parent::isRoutable()`, with old and new signature.
Related to https://github.com/dingo/api/pull/157
Fix https://github.com/dingo/api/pull/156
