### PR TITLE
Fixing cascading exception handlers

### DIFF
--- a/src/Events/ExceptionHandler.php
+++ b/src/Events/ExceptionHandler.php
@@ -6,6 +6,7 @@ use Exception;
 use Dingo\Api\Http\Response;
 use Dingo\Api\Exception\Handler;
 use Dingo\Api\Exception\ResourceException;
+use Illuminate\Http\Response as IlluminateResponse;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class ExceptionHandler
@@ -40,7 +41,11 @@ class ExceptionHandler
         if ($this->handler->willHandle($exception)) {
             $response = $this->handler->handle($exception);
 
-            return Response::makeFromExisting($response);
+            if ($response instanceof IlluminateResponse) {
+                $response = Response::makeFromExisting($response);
+            }
+
+            return $response;
         } elseif (! $exception instanceof HttpExceptionInterface) {
             throw $exception;
         }

--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -41,11 +41,13 @@ class Handler
             if ($exception instanceof $hint) {
                 $response = call_user_func($handler, $exception);
 
-                if (! $response instanceof Response) {
-                    $response = new Response($response, $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 200);
-                }
+                if (! is_null($response)) {
+                    if (! $response instanceof Response) {
+                        $response = new Response($response, $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 200);
+                    }
 
-                return $response;
+                    return $response;
+                }
             }
         }
     }


### PR DESCRIPTION
**Moved from #174**

As discussed in dingo/api#170.

Only creates a Response object if the exception handler callback does not return null.
