### PR TITLE
Fix to prevent routes to be catched if declared outside of api scope

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -317,7 +317,7 @@ class Router extends IlluminateRouter
         $collection = $this->getApiRouteCollectionFromRequest($request) ?: $this->getDefaultApiRouteCollection();
 
         try {
-            $collection->matchesRequest($request);
+            $collection->match($request);
         } catch (NotFoundHttpException $exception) {
             return $this->requestsTargettingApi[$key] = false;
         } catch (MethodNotAllowedHttpException $exception) {


### PR DESCRIPTION
See #176 
