### PR TITLE
Docblock fix in FractalTransformer

### DIFF
--- a/src/Transformer/FractalTransformer.php
+++ b/src/Transformer/FractalTransformer.php
@@ -97,7 +97,7 @@ class FractalTransformer extends Transformer
      * @param  mixed  $response
      * @param  \League\Fractal\TransformerAbstract  $transformer
      * @param  array  $parameters
-     * @return \League\Fractal\Resource\Item|\League|Fractal\Resource\Collection
+     * @return \League\Fractal\Resource\Item|\League\Fractal\Resource\Collection
      */
     protected function createResource($response, $transformer, array $parameters)
     {


### PR DESCRIPTION
Fixed the reference to `\League\Fractal\Resource\Collection`.
