### PR TITLE
Add a ResponseFactory::noContent() to responde with 204 No content.

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -46,6 +46,19 @@ class ResponseFactory
     }
 
     /**
+     * Respond with a no content response.
+     *
+     * @return \Dingo\Api\Http\ResponseBuilder
+     */
+    public function noContent()
+    {
+        $response = new ResponseBuilder(null);
+        $response->setStatusCode(204);
+
+        return $response;
+    }
+
+    /**
      * Bind a collection to a transformer and start building a response.
      *
      * @param  \Illuminate\Support\Collection  $collection

--- a/tests/Http/ResponseFactoryTest.php
+++ b/tests/Http/ResponseFactoryTest.php
@@ -23,6 +23,7 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase
         Mockery::close();
     }
 
+
     public function testMakingACreatedResponse()
     {
         $response = $this->factory->created()->build();
@@ -34,6 +35,14 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($responseWithLocation->getStatusCode(), 201);
         $this->assertTrue($responseWithLocation->headers->has('Location'));
         $this->assertEquals($responseWithLocation->headers->get('Location'), 'test');
+    }
+
+
+    public function testMakingANoContentResponse()
+    {
+        $response = $this->factory->noContent()->build();
+        $this->assertEquals($response->getStatusCode(), 204);
+        $this->assertEquals($response->getContent(), '');
     }
 
 


### PR DESCRIPTION
This addition in ResponseFactory allows us to respond with a `return $this->noContent();` which will return a `204 No Content`. This kind of response are usually expected in a `DELETE` action.
