### PR TITLE
Fix call to undefined getCurrentRequest.

### DIFF
--- a/src/Transformer/FractalTransformer.php
+++ b/src/Transformer/FractalTransformer.php
@@ -53,8 +53,8 @@ class FractalTransformer implements TransformerInterface
      *
      * @param  mixed  $response
      * @param  object  $transformer
-     * @param  \Dingo\Api\Transformer\Binding
-     * @param  \Illuminate\Http\Request
+     * @param  \Dingo\Api\Transformer\Binding  $binding
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function transform($response, $transformer, Binding $binding, Request $request)
@@ -114,7 +114,7 @@ class FractalTransformer implements TransformerInterface
     /**
      * Parse includes.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  \Illuminate\Http\Request  $request
      * @return void
      */
     public function parseFractalIncludes(Request $request)


### PR DESCRIPTION
Per https://github.com/dingo/api/issues/225, FractalTransformer fails because there is no getCurrentRequest method. Here's one way to fix it, but maybe you had other thoughts...
