### PR TITLE
Throw an Exception for invalid API version

### DIFF
--- a/src/Routing/GroupCollection.php
+++ b/src/Routing/GroupCollection.php
@@ -31,7 +31,7 @@ class GroupCollection
     /**
      * Create a new version collection instance.
      *
-     * @param  \Dingo\Api\Config  $config
+     * @param \Dingo\Api\Config $config
      *
      * @return void
      */
@@ -43,8 +43,8 @@ class GroupCollection
     /**
      * Add a group to the collection.
      *
-     * @param  string  $version
-     * @param  array  $options
+     * @param string $version
+     * @param array  $options
      *
      * @return \Dingo\Api\Routing\RouteCollection
      */
@@ -58,7 +58,7 @@ class GroupCollection
     /**
      * Determine if the version exists on the collection.
      *
-     * @param  string  $version
+     * @param string $version
      *
      * @return bool
      */
@@ -70,7 +70,7 @@ class GroupCollection
     /**
      * Get a matching API route collection from the request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
      *
      * @return \Dingo\Api\Routing\RouteCollection|null
      */
@@ -94,9 +94,7 @@ class GroupCollection
     /**
      * Get an API route collection for a given version.
      *
-     * @param  string  $version
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @param string $version
      *
      * @return \Dingo\Api\Routing\RouteCollection|null
      */
@@ -110,8 +108,8 @@ class GroupCollection
     /**
      * Get an API route collection for a given domain and optionally a version.
      *
-     * @param  string  $domain
-     * @param  string  $version
+     * @param string $domain
+     * @param string $version
      *
      * @return \Dingo\Api\Routing\RouteCollection|null
      */
@@ -129,8 +127,8 @@ class GroupCollection
     /**
      * Get an aPI route collection for a given domain or a given version.
      *
-     * @param  string  $domain
-     * @param  string  $version
+     * @param string $domain
+     * @param string $version
      *
      * @return \Dingo\Api\Routing\RouteCollection|null
      */
@@ -146,7 +144,7 @@ class GroupCollection
     /**
      * Get an API route collection for a given array of options.
      *
-     * @param  array  $options
+     * @param array $options
      *
      * @return array
      */


### PR DESCRIPTION
When requesting invalid API version, throw an exception which gets transformed into JSON response.
Fixes #281 
