### PR TITLE
[Proposal] Pagination processing is not perfect

### DIFF
--- a/src/Transformer/TransformerFactory.php
+++ b/src/Transformer/TransformerFactory.php
@@ -170,7 +170,7 @@ class TransformerFactory
     protected function hasBinding($class)
     {
         if ($this->isCollection($class) && ! $class->isEmpty()) {
-            $class = $class->first();
+            $class = (object) $class->first();
         }
 
         $class = is_object($class) ? get_class($class) : $class;


### PR DESCRIPTION
Custom Paginator object, not necessarily all elements of an object;

``` php
$items = array(.....);
$paginator = Paginator::make($items, $totalItems, $perPage);

...

API::reponse()->array($paginator);
```

![image](https://cloud.githubusercontent.com/assets/1472352/5388423/66d8309a-8125-11e4-8266-e6b118c61ffa.png)
