### PR TITLE
Add errorMethodNotAllowed() error response

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -206,6 +206,18 @@ class ResponseFactory
     }
 
     /**
+     * Return a 405 method not allowed error.
+     *
+     * @param string|array $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function errorMethodNotAllowed($message = 'Method not allowed')
+    {
+        return $this->error($message, 405);
+    }
+
+    /**
      * Call magic methods beginning with "with".
      *
      * @param string $method


### PR DESCRIPTION
Useful for when not all resource methods are to be accessible via an API controller and a consistent response should be returned
