### PR TITLE
Include changes

### DIFF
--- a/src/Transformer/FractalTransformer.php
+++ b/src/Transformer/FractalTransformer.php
@@ -158,9 +158,7 @@ class FractalTransformer implements TransformerInterface
      */
     public function getEagerLoads($transformer, $requestedIncludes)
     {
-        if(!is_array($requestedIncludes)) {
-            $requestedIncludes = array($requestedIncludes);
-        }
+        $requestedIncludes = (array) $requestedIncludes; // Ensure $requestedIncludeStrings is an array
 
         $availableRequestedIncludes = array_intersect($transformer->getAvailableIncludes(), $requestedIncludes);
         $defaultIncludes = $transformer->getDefaultIncludes();

--- a/src/Transformer/FractalTransformer.php
+++ b/src/Transformer/FractalTransformer.php
@@ -158,8 +158,9 @@ class FractalTransformer implements TransformerInterface
      */
     public function getEagerLoads($transformer, $requestedIncludes)
     {
-        if(!is_array($requestedIncludes))
+        if(!is_array($requestedIncludes)) {
             $requestedIncludes = array($requestedIncludes);
+        }
 
         $availableRequestedIncludes = array_intersect($transformer->getAvailableIncludes(), $requestedIncludes);
         $defaultIncludes = $transformer->getDefaultIncludes();

--- a/src/Transformer/FractalTransformer.php
+++ b/src/Transformer/FractalTransformer.php
@@ -150,10 +150,11 @@ class FractalTransformer implements TransformerInterface
     }
 
     /**
-     * Get includes as their array keys for eager loading
+     * Get includes as their array keys for eager loading.
      *
-     * @param  array|string $requestedIncludes
-     * @return array
+     * @param string|string[] $requestedIncludes
+     *
+     * @return string[]
      */
     public function getEagerLoads($transformer, $requestedIncludes)
     {
@@ -178,5 +179,4 @@ class FractalTransformer implements TransformerInterface
 
         return $eagerLoads;
     }
-
 }


### PR DESCRIPTION
A combination of $defaultIncludes and parsed $requestedIncludes is now pulled from the transformer for eager loading.

```php
protected $defaultIncludes = [
    'invite',
    'login',
];

protected $availableIncludes = [
    'posts',
];
```

Include keys can now be defined on the transformer to allow nested includes (A feature of Fractal that was no longer accessible in this package).

```php
protected $availableIncludes = [
    'group.admin' => 'admin',
];
```


Array syntax can now be used for requesting includes.
`users?include[]=login&include[]=invite`


*Update*
Nested includes using dot notation were [already available](https://github.com/thephpleague/fractal/issues/151#issuecomment-70772631) in Fractal, without you having to specify a key for it. They just don't work in `JsonApiSerializer` (For which I might submit a PR sometime in the future).