### PR TITLE
Allow item() and collection() to be called without a Transformer (IDE fix)

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -71,7 +71,7 @@ class ResponseFactory
      *
      * @return \Dingo\Api\Http\ResponseBuilder
      */
-    public function collection($collection, $transformer, array $parameters = [], Closure $after = null)
+    public function collection($collection, $transformer = null, array $parameters = [], Closure $after = null)
     {
         if ($collection->isEmpty()) {
             $class = get_class($collection);
@@ -94,7 +94,7 @@ class ResponseFactory
      *
      * @return \Dingo\Api\Http\ResponseBuilder
      */
-    public function item($item, $transformer, array $parameters = [], Closure $after = null)
+    public function item($item, $transformer = null, array $parameters = [], Closure $after = null)
     {
         $class = get_class($item);
 

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -64,10 +64,10 @@ class ResponseFactory
     /**
      * Bind a collection to a transformer and start building a response.
      *
-     * @param object   $collection
-     * @param object   $transformer
-     * @param array    $parameters
-     * @param \Closure $after
+     * @param object        $collection
+     * @param object|null   $transformer
+     * @param array         $parameters
+     * @param \Closure      $after
      *
      * @return \Dingo\Api\Http\ResponseBuilder
      */
@@ -87,10 +87,10 @@ class ResponseFactory
     /**
      * Bind an item to a transformer and start building a response.
      *
-     * @param object   $item
-     * @param object   $transformer
-     * @param array    $parameters
-     * @param \Closure $after
+     * @param object        $item
+     * @param object|null   $transformer
+     * @param array         $parameters
+     * @param \Closure      $after
      *
      * @return \Dingo\Api\Http\ResponseBuilder
      */


### PR DESCRIPTION
When implementing the `TransformableInterface` in the model, there's no longer a need to pass a Transformer to the `item()` and `collection()` methods. This functionality is allowed by dingo, and no errors are thrown.

However, the IDE will squawk when I call `$this->response->item($model)` because the parameter doesn't have a default value set.
![screen shot 2015-01-11 at 02 05 13](https://cloud.githubusercontent.com/assets/3620912/5694399/549f205e-9936-11e4-8d63-615425dc01e8.png)

Defaulting $transformer to null fixed the IDE problem, and I can't think of a scenario where adding this will cause an error.

Let me know what you think @jasonlewis :)