### PR TITLE
camel casing on exception output for consistency

### DIFF
--- a/src/Event/ExceptionHandler.php
+++ b/src/Event/ExceptionHandler.php
@@ -61,10 +61,18 @@ class ExceptionHandler
             $message = sprintf('%d %s', $exception->getStatusCode(), Response::$statusTexts[$exception->getStatusCode()]);
         }
 
-        $response = ['message' => $message, 'status_code' => $exception->getStatusCode()];
+        $response = ['message' => $message, 'statusCode' => $exception->getStatusCode()];
 
         if ($exception instanceof ResourceException && $exception->hasErrors()) {
-            $response['errors'] = $exception->getErrors();
+            $errorArray = $exception->getErrors()->toArray();
+
+            $camelCasedErrorArray = [];
+            foreach ($errorArray as $key => $value) {
+                $camelCasedErrorArray[camel_case($key)] = $value;
+            }
+
+            $response['errors'] = $camelCasedErrorArray;
+            unset($errorArray, $camelCasedErrorArray);
         }
 
         if ($code = $exception->getCode()) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -69,6 +69,22 @@ class Response extends IlluminateResponse
         } elseif ($content instanceof EloquentCollection) {
             $content = $formatter->formatEloquentCollection($content);
         } elseif (is_array($content) || $content instanceof ArrayObject || $content instanceof ArrayableInterface) {
+            
+            //check if meta key exists for pagination data
+            if(array_key_exists('meta', $content)) {
+
+                //get the meta data
+                $meta = $content['meta'];
+
+                //set a header for each pagination item in the meta data
+                foreach ($meta['pagination'] as $key => $val) {
+                    $this->headers->set(camel_case('pagination_'.$key), $val);
+                }
+
+                //remove the meta data from the array
+                unset($content['meta']);
+            }
+
             $content = $formatter->formatArray($content);
         } else {
             $this->headers->set('content-type', $defaultContentType);

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -141,7 +141,7 @@ class ResponseFactory
             $error = ['message' => $error];
         }
 
-        $error = array_merge(['status_code'  => $statusCode], $error);
+        $error = array_merge(['statusCode'  => $statusCode], $error);
 
         return $this->array($error)->setStatusCode($statusCode);
     }


### PR DESCRIPTION
For the sake of API niceless and consistency, changes such that when exceptions are thrown, the error data has camel cased keys.