### PR TITLE
updating jwt-auth and oauth2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "league/fractal": "0.11.*"
     },
     "require-dev": {
-        "lucadegasperi/oauth2-server-laravel": "3.0.*",
-        "tymon/jwt-auth": "0.3.*",
+        "lucadegasperi/oauth2-server-laravel": "4.0.x@dev",
+        "tymon/jwt-auth": "0.5.*",
         "illuminate/routing": "5.0.*",
         "illuminate/events": "5.0.*",
         "illuminate/auth": "5.0.*",

--- a/src/Auth/JWTProvider.php
+++ b/src/Auth/JWTProvider.php
@@ -43,7 +43,7 @@ class JWTProvider extends AuthorizationProvider
         $token = $this->getToken($request);
 
         try {
-            return $this->auth->login($token);
+            return $this->auth->setToken($token)->authenticate();
         } catch (JWTException $e) {
             throw new UnauthorizedHttpException('JWTAuth', $e->getMessage());
         }

--- a/tests/Auth/JWTProviderTest.php
+++ b/tests/Auth/JWTProviderTest.php
@@ -6,7 +6,7 @@ use Mockery;
 use Illuminate\Http\Request;
 use Dingo\Api\Routing\Route;
 use Dingo\Api\Auth\JWTProvider;
-use Tymon\JWTAuth\Exceptions\JWTAuthException;
+use Tymon\JWTAuth\Exceptions\JWTException;
 use PHPUnit_Framework_TestCase;
 
 class JWTProviderTest extends PHPUnit_Framework_TestCase
@@ -39,7 +39,8 @@ class JWTProviderTest extends PHPUnit_Framework_TestCase
         $request = Request::create('foo', 'GET');
         $request->headers->set('authorization', 'Bearer foo');
 
-        $this->auth->shouldReceive('login')->with('foo')->andThrow(new JWTAuthException('foo'));
+        $this->auth->shouldReceive('setToken')->with('foo')->andReturn(Mockery::self());
+        $this->auth->shouldReceive('authenticate')->once()->andThrow(new JWTException('foo'));
 
         $this->provider->authenticate($request, new Route('/foo', 'GET', []));
     }
@@ -49,7 +50,8 @@ class JWTProviderTest extends PHPUnit_Framework_TestCase
         $request = Request::create('foo', 'GET');
         $request->headers->set('authorization', 'Bearer foo');
 
-        $this->auth->shouldReceive('login')->with('foo')->andReturn((object) ['id' => 1]);
+        $this->auth->shouldReceive('setToken')->with('foo')->andReturn(Mockery::self());
+        $this->auth->shouldReceive('authenticate')->once()->andReturn((object) ['id' => 1]);
 
         $this->assertEquals(1, $this->provider->authenticate($request, new Route('/foo', 'GET', []))->id);
     }
@@ -58,7 +60,8 @@ class JWTProviderTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('foo', 'GET', ['token' => 'foo']);
 
-        $this->auth->shouldReceive('login')->with('foo')->andReturn((object) ['id' => 1]);
+        $this->auth->shouldReceive('setToken')->with('foo')->andReturn(Mockery::self());
+        $this->auth->shouldReceive('authenticate')->once()->andReturn((object) ['id' => 1]);
 
         $this->assertEquals(1, $this->provider->authenticate($request, new Route('/foo', 'GET', []))->id);
     }


### PR DESCRIPTION
Thought I would get the ball rolling a little bit here :)

I have updated jwt-auth to use `0.5.*` and updated the tests.
Also updated lucadegasperi/oauth2-server-laravel to `4.0.x@dev` for now.

Obviously tests are failing at this point (Auth ones pass), but don't error anymore :)