### PR TITLE
Ensure that API filters are the first executed

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -42,9 +42,12 @@ class Route extends IlluminateRoute
         }
 
         foreach ([static::API_FILTER_THROTTLE, static::API_FILTER_AUTH] as $filter) {
-            if (array_search($filter, $action['before']) === false) {
-                array_unshift($action['before'], $filter);
+            $key = array_search($filter, $action['before']);
+            if ($key !== false) {
+                unset($action['before'][$key]);
             }
+
+            array_unshift($action['before'], $filter);
         }
 
         return $action;

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Dingo\Api\Tests\Routing;
+
+use Dingo\Api\Routing\Route;
+use Mockery as m;
+use PHPUnit_Framework_TestCase;
+
+class RouteTest extends PHPUnit_Framework_TestCase
+{
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testApiFiltersAreSet()
+    {
+        // Example : my_uri is a route with a 'foo' before filter
+        $route = new Route(
+            ['GET'],
+            'my_uri',
+            [
+                'as' => 'my.uri',
+                'before' => ['foo'],
+                function() {
+                    return 'bar';
+                }
+            ]
+        );
+
+        $action = $route->getAction();
+        $this->assertEquals([Route::API_FILTER_AUTH, Route::API_FILTER_THROTTLE, 'foo'], $action['before']);
+    }
+
+    public function testApiFiltersAreFirstBeforeFilters()
+    {
+        // Example : my_uri is a route of a group with a 'foo' before filter
+        $route = new Route(
+            ['GET'],
+            'my_uri',
+            [
+                'as' => 'my.uri',
+                'before' => ['foo', Route::API_FILTER_THROTTLE, Route::API_FILTER_AUTH],
+                function() {
+                    return 'bar';
+                }
+            ]
+        );
+
+        $action = $route->getAction();
+        $this->assertEquals([Route::API_FILTER_AUTH, Route::API_FILTER_THROTTLE, 'foo'], $action['before']);
+    }
+}


### PR DESCRIPTION
Hi,

I encountered an issue with Laravel route group filters and dingo API basic authentification provider today.

Let's suppose that we are requesting `/api/foo/bar` with a valid HTTP basic authentification header and that we have this `routes.php` file :
```php
Route::api(
    [
        'version' => 'v1',
        'prefix' => 'api',
        'protected' => true,
    ],
    function () {
        Route::group(
        [
            'prefix' => 'foo',
            'before' => 'foo',
        ],
        function () {
             Route::get(
                 '/bar',
                 [
                     'as' => 'foo.bar',
                     'uses' => 'FooController@bar'
                 ]
             );
        }
    }
);
```


In that case, I observe that the `foo` filter is executed before the user basic authentification one. But with this behavior, I can't do any user validation in `foo` filter because no user is logged in yet.

I think that every API filters should be executed before any others to avoid this issue.

Laravel has this routing behavior (in a short form ^^) :
```php
$action = Route::parseAction($routeData);
$groupAction = $groupData + $action;
$fullAction = Route::parseAction($groupAction);
```

So the API filters must be deleted (if exist) and placed in the beginning of filters array in every `Route::parseAction()` call.