### PR TITLE
added responseFormatInterface

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -104,7 +104,7 @@ class Response extends IlluminateResponse
      *
      * @throws \RuntimeException
      *
-     * @return \Dingo\Api\Http\Format\FormatInterface
+     * @return \Dingo\Api\Http\ResponseFormat\ResponseFormatInterface
      */
     public static function getFormatter($format)
     {

--- a/src/Http/ResponseFormat/ResponseFormat.php
+++ b/src/Http/ResponseFormat/ResponseFormat.php
@@ -2,7 +2,9 @@
 
 namespace Dingo\Api\Http\ResponseFormat;
 
-abstract class ResponseFormat
+use Dingo\Api\Http\ResponseFormat\ResponseFormatInterface;
+
+abstract class ResponseFormat implements ResponseFormatInterface
 {
     /**
      * Illuminate request instance.


### PR DESCRIPTION
In Response class \Dingo\Api\Http\Format\FormatInterface was type hinted but the interface is not present. 

hence created \Dingo\Api\Http\ResponseFormat\ResponseFormatInterface class. 
```
  /**
     * Get the formatter based on the requested format type.
     *
     * @param string $format
     *
     * @throws \RuntimeException
     *
     * @return \Dingo\Api\Http\Format\FormatInterface
     */
    public static function getFormatter($format)
    {
        if (! static::hasFormatter($format)) {
            throw new NotAcceptableHttpException('Unable to format response according to Accept header.');
        }

        return static::$formatters[$format];
    }
```