### PR TITLE
Exceptions now can return any additional data

### DIFF
--- a/src/Exception/ExceptionReplacementsTrait.php
+++ b/src/Exception/ExceptionReplacementsTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Dingo\Api\Exception;
+
+/**
+ * Class ExceptionReplacementsTrait
+ *
+ * Example:
+ * <code><?php
+ * class MyException extends HttpException
+ * {
+ *      use ExceptionReplacementsTrait;
+ * //...
+ * }
+ * $ex = new MyException(); // somewhere in API
+ * $ex->setReplacements([':error' => $errors]);
+ * throw $ex;
+ * ?>
+ * @package Dingo\Api\Exception
+ */
+class ExceptionReplacementsTrait {
+
+    /**
+     * Array of replacements from config/api.php and their values
+     * @var array
+     */
+    public $replacements = [];
+
+    /**
+     * @return array
+     */
+    public function getReplacements()
+    {
+        return $this->replacements;
+    }
+
+    /**
+     * @param array $replacements
+     */
+    public function setReplacements($replacements)
+    {
+        $this->replacements = $replacements;
+    }
+}

--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -167,7 +167,9 @@ class Handler implements ExceptionHandler
             ':message' => $message,
             ':status_code' => $statusCode
         ];
-
+        if (isset($exception->replacements)) {
+            $replacements += $exception->replacements;
+        }
         if ($exception instanceof ResourceException && $exception->hasErrors()) {
             $replacements[':errors'] = $exception->getErrors();
         }

--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -167,7 +167,9 @@ class Handler implements ExceptionHandler
             ':message' => $message,
             ':status_code' => $statusCode
         ];
-        if (isset($exception->replacements)) {
+        if (method_exists($exception, 'getReplacements')) {
+            $replacements += $exception->getReplacements();
+        } elseif (isset($exception->replacements)) {
             $replacements += $exception->replacements;
         }
         if ($exception instanceof ResourceException && $exception->hasErrors()) {


### PR DESCRIPTION
#419 Exceptions which implements DingoException will allow to setup additional replacements.

**Problem:**

I need to add some special fields to error request. The array 'errors' in Dingo custom Exceptions is not enough for me.

For example, i need to send error message:
```
"message": "Oops, some fields looks like incorrect!",
"system_message": "Validation error",
"something": "else",
"yet": ["another", "field"],
"code": 1234,
"status_code": 422,
```

**Resolution:**

In api.php setup new format:
```
'errorFormat' => [
        'message' => ':message',
        'system_message' => ':system_message', // this is a new one
        'errors' => ':errors', // this is an old, but can be used not only in ResourceException childs
...
    ],
```
Use default Exceptions *OR* create the new Exception with public property $replacements;

```
$throw = new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('Lovely bug', null, 123456);

// Here is a new functionality
$throw->replacements = [
    ':errors' => [ 'humans' => 'dead', 'cockroaches' => 'dead' ],
    ':system_message' => $error['system_message'],
    // here you can add any fields, but don't forget to setup them in api.php
];
throw $throw;
```

And now, get this result:

```
{
    "message": "Lovely bug",
    "system_message": "All is dead",
    "errors": {
        "humans": [
            "dead"
        ],
        "cockroaches": [
            "dead"
        ]
    },
    "code": 123456,
    "status_code": 400
}
```