### PR TITLE
Drop Laravel 5.0 and PHP 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 5.4
+  - 5.5.9
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,20 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/routing": "5.0.*|5.1.*",
-        "illuminate/support": "5.0.*|5.1.*",
+        "php": ">=5.5.9",
+        "illuminate/routing": "5.1.*",
+        "illuminate/support": "5.1.*",
         "league/fractal": "0.12.*"
     },
     "require-dev": {
         "lucadegasperi/oauth2-server-laravel": "4.1.*@dev",
         "tymon/jwt-auth": "0.5.*",
-        "illuminate/auth": "5.0.*",
-        "illuminate/cache": "5.0.*",
-        "illuminate/database": "5.0.*",
-        "illuminate/pagination": "5.0.*",
-        "illuminate/console": "5.0.*",
-        "illuminate/filesystem": "5.0.*",
+        "illuminate/auth": "5.1.*",
+        "illuminate/cache": "5.1.*",
+        "illuminate/database": "5.1.*",
+        "illuminate/pagination": "5.1.*",
+        "illuminate/console": "5.1.*",
+        "illuminate/filesystem": "5.1.*",
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~2.0"
@@ -46,5 +46,7 @@
         "branch-alias": {
             "dev-develop": "0.9-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Since PHP 5.4 will be “end of life” in September (no more security fixes), Laravel 5.1 LTS will require PHP 5.5+.</p>&mdash; Laravel (@laravel) <a href="https://twitter.com/laravelphp/status/604301486848270336">May 29, 2015</a></blockquote>

As discussed in #400.