### PR TITLE
Merge config on register

### DIFF
--- a/src/Provider/ApiServiceProvider.php
+++ b/src/Provider/ApiServiceProvider.php
@@ -20,8 +20,6 @@ class ApiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->setupConfig();
-
         $this->app->singleton('Illuminate\Contracts\Debug\ExceptionHandler', function ($app) {
             return $app['api.exception'];
         });
@@ -37,6 +35,7 @@ class ApiServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->setupConfig();
         $this->setupClassAliases();
 
         $this->registerExceptionHandler();


### PR DESCRIPTION
As far as I can tell, you have to merge your config on register() and not on boot().

Before fixing it, on a clean install, I was also getting a

```
ErrorException in Handler.php line 53:
Argument 2 passed to Dingo\Api\Exception\Handler::__construct() must be of the type array, null given, called in /home/vagrant/Code/api/vendor/dingo/api/src/Provider/ApiServiceProvider.php on line 97 and defined in Handler.php line 53
```

A while ago I also bumped into this problem in my own service providers and asked Taylor about it:

```
14:20 < AntonioRibeiro> TaylorOtwell: I'm having to call mergeConfigFrom from register instead of boot, because the package need to have access to (merged) config during register. Do see any problems with this?
14:21 < TaylorOtwel> | nope
14:21 < TaylorOtwel> | i think that's fine
14:21 < TaylorOtwel> | config is unique in that regard
14:21 < TaylorOtwel> | in that it can be done from register
14:21 < TaylorOtwel> | since its loaded very early
14:21 < TaylorOtwel> | in a bootstrapper
```
