### PR TITLE
Fixed version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "league/fractal": "0.12.*"
     },
     "require-dev": {
-        "lucadegasperi/oauth2-server-laravel": "4.1.*@dev",
+        "lucadegasperi/oauth2-server-laravel": "4.1.*",
         "tymon/jwt-auth": "0.5.*",
         "illuminate/auth": "5.1.*",
         "illuminate/cache": "5.1.*",


### PR DESCRIPTION
Composer totally ignores `@dev` when prefer-stable is enabled.