### PR TITLE
Added a pretty print json response.

### DIFF
--- a/src/Http/Response/Format/PrettyJson.php
+++ b/src/Http/Response/Format/PrettyJson.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Dingo\Api\Http\Response\Format;
+
+class PrettyJson extends Json
+{
+    protected function encode($content)
+    {
+        return json_encode($content,JSON_PRETTY_PRINT);
+    }
+}


### PR DESCRIPTION
I'm not sure what the opinion on this will be. But I found use for it in my project, for standard browser viewable responses by setting this as the default and keeping json with no formatting accessible through the accept header.