### PR TITLE
Fixed StyleCI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,6 +2,3 @@ preset: psr2
 
 enabled:
   - short_array_syntax
-
-disabled:
-  - psr0


### PR DESCRIPTION
The psr2 preset on StyleCI no longer enables the psr0 fixer anymore because it doesn't work with psr4 which is the new standard.