### PR TITLE
Fix issue #590 repetition in blueprint generation.

### DIFF
--- a/src/Console/Command/Docs.php
+++ b/src/Console/Command/Docs.php
@@ -149,8 +149,8 @@ class Docs extends Command
         foreach ($this->router->getRoutes() as $collections) {
             foreach ($collections as $route) {
                 if ($controller = $route->getController()) {
-                    if (! $controllers->contains($controller)) {
-                        $controllers->push($controller);
+                    if (! $controllers->contains(get_class($controller))) {
+                        $controllers->put(get_class($controller), $controller);
                     }
                 }
             }


### PR DESCRIPTION
The contains() method was not entirely working with the $controller
object. By adding the class name as a key in the controllers Collection,
The contains() method looks at that string instead.