### PR TITLE
Updated the tags in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,9 @@
 The Dingo API package is meant to provide you, the developer, with a set of tools to help you easily and quickly build your own API. While the goal of this package is to remain as flexible as possible it still won't cover all situations and solve all problems.
 
 [![Build Status](https://img.shields.io/travis/dingo/api/master.svg?style=flat-square)](https://travis-ci.org/dingo/api)
-[![License](https://img.shields.io/packagist/l/dingo/api.svg?style=flat-square)](https://packagist.org/packages/dingo/api)
-![Development Version](https://img.shields.io/packagist/vpre/dingo/api.svg?style=flat-square)
-![Monthly Installs](https://img.shields.io/packagist/dm/dingo/api.svg?style=flat-square)
+[![License](https://img.shields.io/packagist/l/dingo/api.svg?style=flat-square)](LICENSE)
+[![Development Version](https://img.shields.io/packagist/vpre/dingo/api.svg?style=flat-square)](https://packagist.org/packages/dingo/api)
+[![Monthly Installs](https://img.shields.io/packagist/dm/dingo/api.svg?style=flat-square)](https://packagist.org/packages/dingo/api)
 [![StyleCI](https://styleci.io/repos/18673522/shield)](https://styleci.io/repos/18673522)
 
 ## Features


### PR DESCRIPTION
The license now points to the actual license file and the downloads and packagist version point to packagist.