### PR TITLE
Fix issue #640 api:cache command not working when only using dingo router

### DIFF
--- a/src/Console/Command/Cache.php
+++ b/src/Console/Command/Cache.php
@@ -65,9 +65,14 @@ class Cache extends Command
         }
 
         $stub = "app('api.router')->setAdapterRoutes(unserialize(base64_decode('{{routes}}')));";
+        $path = $this->laravel->getCachedRoutesPath();
+
+        if (! $this->files->exists($path)) {
+            $stub = "<?php\n\n$stub";
+        }
 
         $this->files->append(
-            $this->laravel->getCachedRoutesPath(),
+            $path,
             str_replace('{{routes}}', base64_encode(serialize($routes)), $stub)
         );
     }


### PR DESCRIPTION
Issue is explained in #640.
If no route file was generated by `route:cache` command then prepend PHP open tag to route cache file stub.