### PR TITLE
Ignore Lumen storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 phpunit.xml
+storage
 vendor


### PR DESCRIPTION
In case of errors during the tests, if it occurs with Lumen, a `storage/logs/lumen.log` file will be created.
But in no case shall this folder be committed.