### PR TITLE
Fix StyleCI warning

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,4 +9,3 @@ disabled:
   - align_double_arrow
   - new_with_braces
   - ordered_use
-  - psr0


### PR DESCRIPTION
Fix StyleCI PSR-0 warning

    Error details:
    The provided fixer 'psr0' cannot be disabled unless it was already enabled by your preset.