### PR TITLE
Allow includes for non-collections

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -113,6 +113,8 @@ class Fractal implements Adapter
     {
         if ($response instanceof IlluminatePaginator) {
             $response = $response->getCollection();
+        } else {
+            return false;
         }
 
         return $response instanceof EloquentCollection && $this->eagerLoading;


### PR DESCRIPTION
On trying to created an include for datestamps via a date transformer, I found that eager loading always looks for a model relation. Now returns false if the include is not a collection.