### PR TITLE
fixed scopes except not working as expected

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -203,8 +203,8 @@ class Route
             return true;
         } elseif (isset($options['only']) && in_array($this->method, $this->explodeOnPipes($options['only']))) {
             return true;
-        } elseif (isset($options['except']) && in_array($this->method, $this->explodeOnPipes($options['except']))) {
-            return false;
+        } elseif (isset($options['except'])) {
+            return ! in_array($this->method, $this->explodeOnPipes($options['except']));
         } elseif (in_array($this->method, $this->explodeOnPipes($options))) {
             return true;
         }

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -74,5 +74,27 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(20, $route->getRateExpiration(), 'Route did not setup rate limit expiration correctly.');
         $this->assertTrue($route->hasThrottle(), 'Route did not setup throttle correctly.');
         $this->assertInstanceOf('Dingo\Api\Tests\Stubs\BasicThrottleStub', $route->getThrottle(), 'Route did not setup throttle correctly.');
+
+        $route = new Route($this->adapter, $this->container, $request, [
+            'uri' => 'foo/bar',
+            'methods' => ['GET', 'HEAD'],
+            'action' => [
+                'scopes' => ['foo', 'bar'],
+                'providers' => ['foo'],
+                'limit' => 5,
+                'expires' => 10,
+                'throttle' => 'Foo',
+                'version' => ['v1'],
+                'conditionalRequest' => false,
+                'uses' => 'Dingo\Api\Tests\Stubs\RoutingControllerStub@show',
+            ],
+        ]);
+
+        $this->assertEquals(['foo', 'bar', 'baz', 'bing', 'bob'], $route->scopes(), 'Route did not setup scopes correctly.');
+        $this->assertEquals(['foo'], $route->getAuthProviders(), 'Route did not setup authentication providers correctly.');
+        $this->assertEquals(10, $route->getRateLimit(), 'Route did not setup rate limit correctly.');
+        $this->assertEquals(20, $route->getRateExpiration(), 'Route did not setup rate limit expiration correctly.');
+        $this->assertTrue($route->hasThrottle(), 'Route did not setup throttle correctly.');
+        $this->assertInstanceOf('Dingo\Api\Tests\Stubs\BasicThrottleStub', $route->getThrottle(), 'Route did not setup throttle correctly.');
     }
 }

--- a/tests/Stubs/RoutingControllerStub.php
+++ b/tests/Stubs/RoutingControllerStub.php
@@ -25,6 +25,11 @@ class RoutingControllerStub
         return 'foo';
     }
 
+    public function show()
+    {
+        return 'bar';
+    }
+
     public function getIndex()
     {
         return 'foo';


### PR DESCRIPTION
```
$this->scopes('foo', ['except' => 'index']);
```

The above statement should still add the scopes to all other methods, however currently it does not. this should fix.

Also added test.