### PR TITLE
Add properties doc for magic-method properties in Helpers trait.

### DIFF
--- a/src/Routing/Helpers.php
+++ b/src/Routing/Helpers.php
@@ -4,6 +4,12 @@ namespace Dingo\Api\Routing;
 
 use ErrorException;
 
+/**
+ * @property \Dingo\Api\Dispatcher                                            $api
+ * @property \Illuminate\Auth\GenericUser|\Illuminate\Database\Eloquent\Model $user
+ * @property \Dingo\Api\Auth\Auth                                             $auth
+ * @property \Dingo\Api\Http\Response\Factory                                 $response
+ */
 trait Helpers
 {
     /**


### PR DESCRIPTION
Helps IDEs, mostly, and those of us who use them.

I'm assuming there's a reason you use `\Illuminate\Auth\GenericUser|\Illuminate\Database\Eloquent\Model` instead of just `\Illuminate\Contracts\Auth\Authenticatable` so I left it at that.