### PR TITLE
Allow later versions of Fractal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/routing": "~5.1",
         "illuminate/support": "~5.1",
         "dingo/blueprint": "0.1.*",
-        "league/fractal": "0.12.*",
+        "league/fractal": ">=0.12.*",
         "doctrine/annotations": "1.2.*",
         "phpdocumentor/reflection-docblock": "2.0.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/routing": "~5.1",
         "illuminate/support": "~5.1",
         "dingo/blueprint": "0.1.*",
-        "league/fractal": ">=0.12.*",
+        "league/fractal": ">=0.12.0",
         "doctrine/annotations": "1.2.*",
         "phpdocumentor/reflection-docblock": "2.0.*"
     },


### PR DESCRIPTION
Fractal 0.12.0 is the only version accepted. We use 0.13.0. If Dingo doesn't have any need for 0.12 specifically--if so, I'd like to know which parts need to be updated--then 0.12.0 or higher should be here. Hopefully Fractal is following SemVer and the minor update won't break anything.