### PR TITLE
convert from illuminate request to dingo request in transformer factory

### DIFF
--- a/src/Transformer/Factory.php
+++ b/src/Transformer/Factory.php
@@ -4,10 +4,12 @@ namespace Dingo\Api\Transformer;
 
 use Closure;
 use RuntimeException;
+use Dingo\Api\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Dingo\Api\Contract\Transformer\Adapter;
 use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Http\Request as IlluminateRequest;
 
 class Factory
 {
@@ -82,7 +84,7 @@ class Factory
     {
         $binding = $this->getBinding($response);
 
-        return $this->adapter->transform($response, $binding->resolveTransformer(), $binding, $this->container['request']);
+        return $this->adapter->transform($response, $binding->resolveTransformer(), $binding, $this->getRequest());
     }
 
     /**
@@ -223,5 +225,21 @@ class Factory
     public function getAdapter()
     {
         return $this->adapter;
+    }
+
+    /**
+     * Get the request from the container.
+     *
+     * @return \Dingo\Api\Http\Request
+     */
+    public function getRequest()
+    {
+        $request = $this->container['request'];
+
+        if ($request instanceof IlluminateRequest && ! $request instanceof Request) {
+            $request = (new Request())->createFromIlluminate($request);
+        }
+
+        return $request;
     }
 }

--- a/tests/Transformer/FactoryTest.php
+++ b/tests/Transformer/FactoryTest.php
@@ -83,6 +83,20 @@ class FactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([['name' => 'Jason'], ['name' => 'Bob']], $response);
     }
 
+    public function testTransforingWithIlluminateRequest()
+    {
+        $container = new Container;
+        $container['request'] = new \Illuminate\Http\Request();
+
+        $factory = new Factory($container, new TransformerStub);
+
+        $factory->register('Dingo\Api\Tests\Stubs\UserStub', new UserTransformerStub);
+
+        $response = $factory->transform(new UserStub('Jason'));
+
+        $this->assertEquals(['name' => 'Jason'], $response);
+    }
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Unable to find bound transformer for "Dingo\Api\Tests\Stubs\UserStub" class


### PR DESCRIPTION
I was having issues with using the Dispatcher to create internal requests and using the laravel `CrawlerTrait` in > 5.1. When the crawler trait creates a request it creates it as an instance of `Illuminate\Http\Request` and once the controller has executed, it passes the same request to the transformer. So added a `getRequest` to Transformer factory which also converts from `Illuminate\Http\Request` to `Dingo\Api\Http\Request` if the instance of the request is `Illuminate\Http\Request`.