### PR TITLE
Update domain validation ignoring ports.

### DIFF
--- a/src/Http/Validation/Domain.php
+++ b/src/Http/Validation/Domain.php
@@ -7,6 +7,8 @@ use Dingo\Api\Contract\Http\Validator;
 
 class Domain implements Validator
 {
+    const PATTERN_STRIP_PROTOCOL = '/:\d*$/';
+
     /**
      * API domain.
      *
@@ -35,7 +37,7 @@ class Domain implements Validator
      */
     public function validate(Request $request)
     {
-        return ! is_null($this->domain) && $request->header('host') == $this->stripProtocol($this->domain);
+        return ! is_null($this->domain) && $request->getHost() == $this->getStrippedDomain();
     }
 
     /**
@@ -52,5 +54,34 @@ class Domain implements Validator
         }
 
         return $domain;
+    }
+
+    /**
+     * Strip the port from a domain.
+     *
+     * @param $domain
+     *
+     * @return mixed
+     */
+    protected function stripPort($domain)
+    {
+        $domainStripped = preg_replace(self::PATTERN_STRIP_PROTOCOL, '', $domain);
+
+        if ($domainStripped === null) {
+            return $domain;
+        }
+
+        return $domainStripped;
+
+    }
+
+    /**
+     * Get the domain stripped from protocol and port
+     *
+     * @return mixed
+     */
+    protected function getStrippedDomain()
+    {
+        return $this->stripPort($this->stripProtocol($this->domain));
     }
 }

--- a/tests/Http/Validation/DomainTest.php
+++ b/tests/Http/Validation/DomainTest.php
@@ -31,4 +31,22 @@ class DomainTest extends PHPUnit_Framework_TestCase
         $validator = new Domain('https://foo.bar');
         $this->assertTrue($validator->validate(Request::create('http://foo.bar', 'GET')), 'Validation failed when it should have passed with a valid domain.');
     }
+
+    public function testValidationPassesWithPortOnDomain()
+    {
+        $validator = new Domain('http://foo.bar:8888');
+        $this->assertTrue($validator->validate(Request::create('http://foo.bar', 'GET')), 'Validation failed when it should have passed with a valid domain.');
+    }
+
+    public function testValidationPassesWithPortOnRequest()
+    {
+        $validator = new Domain('http://foo.bar');
+        $this->assertTrue($validator->validate(Request::create('http://foo.bar:8888', 'GET')), 'Validation failed when it should have passed with a valid domain.');
+    }
+
+    public function testValidationPassesWithPortOnDomainAndRequest()
+    {
+        $validator = new Domain('http://foo.bar:8888');
+        $this->assertTrue($validator->validate(Request::create('http://foo.bar:8888', 'GET')), 'Validation failed when it should have passed with a valid domain.');
+    }
 }


### PR DESCRIPTION
Setting the API_DOMAIN without port and using this patch seems to fix the issue
fixes #754