### PR TITLE
Separate out Json and JsonAPI formatters

### DIFF
--- a/src/Http/Response/Format/SimpleJson.php
+++ b/src/Http/Response/Format/SimpleJson.php
@@ -2,15 +2,14 @@
 
 namespace Dingo\Api\Http\Response\Format;
 
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
- * Class Json formats results according to the specifications laid out by http://jsonapi.org/
+ * Class SimpleJson formats results in a simple array/object or "plain JSON" format.
  *
  * @package Dingo\Api\Http\Response\Format
  */
-class Json extends Format
+class SimpleJson extends Format
 {
     /**
      * Format an Eloquent model.
@@ -21,13 +20,13 @@ class Json extends Format
      */
     public function formatEloquentModel($model)
     {
-        $key = Str::singular($model->getTable());
+        $key = str_singular($model->getTable());
 
         if (! $model::$snakeAttributes) {
-            $key = Str::camel($key);
+            $key = camel_case($key);
         }
 
-        return $this->encode([$key => $model->toArray()]);
+        return $this->encode($model->toArray());
     }
 
     /**
@@ -44,13 +43,13 @@ class Json extends Format
         }
 
         $model = $collection->first();
-        $key = Str::plural($model->getTable());
+        $key = str_plural($model->getTable());
 
         if (! $model::$snakeAttributes) {
-            $key = Str::camel($key);
+            $key = camel_case($key);
         }
 
-        return $this->encode([$key => $collection->toArray()]);
+        return $this->encode($collection->toArray());
     }
 
     /**

--- a/tests/Http/Response/Format/SimpleJsonTest.php
+++ b/tests/Http/Response/Format/SimpleJsonTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Dingo\Api\Tests\Http\Response\Format;
+
+use Mockery;
+use Dingo\Api\Http\Response;
+use PHPUnit_Framework_TestCase;
+use Illuminate\Support\MessageBag;
+use Dingo\Api\Http\Response\Format\SimpleJson;
+use Dingo\Api\Tests\Stubs\EloquentModelStub;
+use Illuminate\Database\Eloquent\Collection;
+
+class SimpleJsonTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        Response::setFormatters(['json' => new SimpleJson]);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+
+        EloquentModelStub::$snakeAttributes = true;
+
+        Response::setFormatters([]);
+    }
+
+    public function testMorphingEloquentModel()
+    {
+        $response = (new Response(new EloquentModelStub))->morph();
+
+        $this->assertEquals('{"foo":"bar"}', $response->getContent());
+    }
+
+    public function testMorphingEloquentCollection()
+    {
+        $response = (new Response(new Collection([new EloquentModelStub, new EloquentModelStub])))->morph();
+
+        $this->assertEquals('[{"foo":"bar"},{"foo":"bar"}]', $response->getContent());
+    }
+
+    public function testMorphingEmptyEloquentCollection()
+    {
+        $response = (new Response(new Collection))->morph();
+
+        $this->assertEquals('[]', $response->getContent());
+    }
+
+    public function testMorphingString()
+    {
+        $response = (new Response('foo'))->morph();
+
+        $this->assertEquals('foo', $response->getContent());
+    }
+
+    public function testMorphingArray()
+    {
+        $messages = new MessageBag(['foo' => 'bar']);
+
+        $response = (new Response(['foo' => 'bar', 'baz' => $messages]))->morph();
+
+        $this->assertEquals('{"foo":"bar","baz":{"foo":["bar"]}}', $response->getContent());
+    }
+
+    public function testMorphingUnknownType()
+    {
+        $this->assertEquals(1, (new Response(1))->morph()->getContent());
+    }
+
+    public function testMorphingEloquentModelWithCamelCasing()
+    {
+        EloquentModelStub::$snakeAttributes = false;
+
+        $response = (new Response(new EloquentModelStub))->morph();
+
+        $this->assertEquals('{"foo":"bar"}', $response->getContent());
+    }
+
+    public function testMorphingEloquentCollectionWithCamelCasing()
+    {
+        EloquentModelStub::$snakeAttributes = false;
+
+        $response = (new Response(new Collection([new EloquentModelStub, new EloquentModelStub])))->morph();
+
+        $this->assertEquals('[{"foo":"bar"},{"foo":"bar"}]', $response->getContent());
+    }
+}


### PR DESCRIPTION
For some applications it may be favourable to provide a simple JSON api,
one which returns objects and arrays instead of the structured jsonapi
approach. The new SimpleJson class does not wrap eloquent models or
collections with keys.

I haven't added documentation for it yet, but I can do so if you would would
like to merge this PR.