### PR TITLE
Scope Identifiers not getting passed down to the Fractal Scope

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -99,8 +99,8 @@ class Fractal implements Adapter
         $binding->fireCallback($resource, $this->fractal);
 
         $scopeIdentifier = null;
-        if (array_key_exists("scopeIdentifier", $binding->getParameters())) {
-            $scopeIdentifier = $binding->getParameters()["scopeIdentifier"];
+        if (array_key_exists('scopeIdentifier', $binding->getParameters())) {
+            $scopeIdentifier = $binding->getParameters()['scopeIdentifier'];
         }
 
         return $this->fractal->createData($resource, $scopeIdentifier)->toArray();

--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -98,7 +98,12 @@ class Fractal implements Adapter
 
         $binding->fireCallback($resource, $this->fractal);
 
-        return $this->fractal->createData($resource)->toArray();
+        $scopeIdentifier = null;
+        if (array_key_exists("scopeIdentifier", $binding->getParameters())) {
+            $scopeIdentifier = $binding->getParameters()["scopeIdentifier"];
+        }
+
+        return $this->fractal->createData($resource, $scopeIdentifier)->toArray();
     }
 
     /**


### PR DESCRIPTION
 - Extracted new key "scopeIdentifier" from the parameters passed into the binding
 - Pushed scopeIdentifier into the fractal scope instantiation