### PR TITLE
Move the SetupConfig method to register and not in boot

### DIFF
--- a/src/Provider/ApiServiceProvider.php
+++ b/src/Provider/ApiServiceProvider.php
@@ -23,8 +23,6 @@ abstract class ApiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
-
         Http\Response::setFormatters($this->prepareConfigValues($this->app['config']['api.formats']));
         Http\Response::setTransformer($this->app['api.transformer']);
         Http\Response::setEventDispatcher($this->app['events']);
@@ -44,7 +42,7 @@ abstract class ApiServiceProvider extends ServiceProvider
         $this->setupClassAliases();
 
         $this->setupConfig();
-        
+
         $this->registerExceptionHandler();
         $this->registerDispatcher();
         $this->registerAuth();

--- a/src/Provider/ApiServiceProvider.php
+++ b/src/Provider/ApiServiceProvider.php
@@ -23,7 +23,7 @@ abstract class ApiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->setupConfig();
+
 
         Http\Response::setFormatters($this->prepareConfigValues($this->app['config']['api.formats']));
         Http\Response::setTransformer($this->app['api.transformer']);
@@ -43,6 +43,8 @@ abstract class ApiServiceProvider extends ServiceProvider
     {
         $this->setupClassAliases();
 
+        $this->setupConfig();
+        
         $this->registerExceptionHandler();
         $this->registerDispatcher();
         $this->registerAuth();


### PR DESCRIPTION
when running a test in an application i notice that the config is being
register in the boot method and not in the register of the service
provider, this causes that when the register exception handler method
is called, the config is null since the boot method has not been called
yet. I discover this in a test that i was writing for my application
and i got this
```
Hechoenlaravel\JarvisFoundation\Tests\EntityEntries\TestEntriesCommands::test_it_validates_an_entry_for_entity_and_throws_exception_if_missing_data
ErrorException: Argument 2 passed to
Dingo\Api\Exception\Handler::__construct() must be of the type array,
null given, called in
/home/vagrant/Code/jarvis-platform/packages/hechoenlaravel/jarvis-founda
tion/vendor/dingo/api/src/Provider/ApiServiceProvider.php on line 125
and defined 
```
after some debugging i was able to find that.