### PR TITLE
Middleware request fix

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -9,14 +9,14 @@ use Illuminate\Pipeline\Pipeline;
 use Dingo\Api\Http\RequestValidator;
 use Dingo\Api\Http\Request as HttpRequest;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container as Application;
 
 class Request
 {
     /**
      * Application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $app;
 
@@ -51,7 +51,7 @@ class Request
     /**
      * Create a new request middleware instance.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Illuminate\Contracts\Container\Container    $app
      * @param \Dingo\Api\Contract\Debug\ExceptionHandler   $exception
      * @param \Dingo\Api\Routing\Router                    $router
      * @param \Dingo\Api\Http\RequestValidator             $validator


### PR DESCRIPTION
With the latest version, I had the following error with fresh installation:

```
ErrorException in Request.php line 62:
Argument 1 passed to Dingo\Api\Http\Middleware\Request::__construct() must be an instance of Illuminate\Contracts\Foundation\Application, instance of Laravel\Lumen\Application given, called in /var/www/html/school/vendor/dingo/api/src/Provider/ApiServiceProvider.php on line 279 and defined
```