### PR TITLE
Set the userResolver on Http\Request

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -41,6 +41,7 @@ class Request extends IlluminateRequest implements RequestInterface
         }
 
         $new->setRouteResolver($old->getRouteResolver());
+        $new->setUserResolver($old->getUserResolver());
 
         return $new;
     }


### PR DESCRIPTION
By adding this one line you will enable support for Lumen 5.2 and their authentication system. This doesn't appear to break the default authentication included with this package either as that code does not pull the `userResolver` object anywhere.

What is nice here is the developer can now include `\Illuminate\Auth\GuardHelpers` as well as `\Dingo\Api\Routing\Helpers`. The developer would then use `$request->user()` instead of `$this->user()` to access the user object, but they can still use everything else your Helpers trait provides (throttling).