### PR TITLE
Change ModelNotFoundException to NotFoundHttpException

### DIFF
--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -7,6 +7,8 @@ use ReflectionFunction;
 use Illuminate\Http\Response;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
 use Dingo\Api\Contract\Debug\MessageBagErrors;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Illuminate\Contracts\Debug\ExceptionHandler as IlluminateExceptionHandler;
 
@@ -138,6 +140,10 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
 
                 return $response;
             }
+        }
+
+        if ($exception instanceof ModelNotFoundException) {
+            $exception = new NotFoundHttpException($exception->getMessage(), $exception);
         }
 
         return $this->genericResponse($exception);


### PR DESCRIPTION
This is needed since `ModelNotFoundException` throws error code 500. A change to `NotFoundHttpException` is needed in order for it to throw error code 404 instead.

ModelNotFoundException happens when using Laravel's explicit model binding and whenever the Id of the Model being queried doesn't exist.