### PR TITLE
api:routes artisan command action display fix

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -394,7 +394,7 @@ class Router
     public function addRoute($methods, $uri, $action)
     {
         if (is_string($action)) {
-            $action = ['uses' => $action];
+            $action = ['uses' => $action, 'controller' => $action];
         } elseif ($action instanceof Closure) {
             $action = [$action];
         }


### PR DESCRIPTION
Problem:
Actions of all routes in api:routes command was displayed like closure.

Before:
![before](http://dl3.joxi.net/drive/0002/2750/154302/160305/3509f9a01b.jpg)

After:
![after](http://dl3.joxi.net/drive/0002/2750/154302/160305/2868571c77.jpg)