### PR TITLE
Pass server variables to internal request

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -466,7 +466,15 @@ class Dispatcher
             $uri = rtrim($this->getRootRequest()->root(), '/').'/'.ltrim($uri, '/');
         }
 
-        $request = InternalRequest::create($uri, $verb, $parameters, $this->cookies, $this->uploads, [], $this->content);
+        $request = InternalRequest::create(
+            $uri,
+            $verb,
+            $parameters,
+            $this->cookies,
+            $this->uploads,
+            $this->container['request']->server->all(),
+            $this->content
+        );
 
         $request->headers->set('host', $this->getDomain());
 


### PR DESCRIPTION
In my API implementation I am trying to return some URLs generated with Laravel's route() helper. The problem is that Dispatcher does not pass server variables from actual request into the internal request and links generated with route() are quite random (pointing to http://localhost for example).

Is this ok to pass all actual server variables instead of the empty array? It would solve my problem.