### PR TITLE
Added a test for Contract\Routing\Adapter::getIterableRoutes()

### DIFF
--- a/tests/Routing/Adapter/BaseAdapterTest.php
+++ b/tests/Routing/Adapter/BaseAdapterTest.php
@@ -226,7 +226,7 @@ abstract class BaseAdapterTest extends PHPUnit_Framework_TestCase
         });
 
         $routes = $this->adapter->getIterableRoutes();
-        $this->assertEquals('v1', key($routes));
+        $this->assertTrue(array_key_exists('v1', (array) $routes));
         $this->assertEquals(2, count($routes['v1']));
     }
 }

--- a/tests/Routing/Adapter/BaseAdapterTest.php
+++ b/tests/Routing/Adapter/BaseAdapterTest.php
@@ -217,4 +217,16 @@ abstract class BaseAdapterTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', $this->router->dispatch($request)->getContent(), 'Router did not register controller correctly.');
     }
+
+    public function testIterableRoutes()
+    {
+        $this->router->version('v1', ['namespace' => 'Dingo\Api\Tests\Stubs'], function () {
+            $this->router->post('/', ['uses' => 'RoutingControllerStub@index']);
+            $this->router->post('/find', ['uses' => 'RoutingControllerOtherStub@show']);
+        });
+
+        $routes = $this->adapter->getIterableRoutes();
+        $this->assertEquals('v1', key($routes));
+        $this->assertEquals(2, count($routes['v1']));
+    }
 }

--- a/tests/Stubs/RoutingControllerOtherStub.php
+++ b/tests/Stubs/RoutingControllerOtherStub.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Dingo\Api\Tests\Stubs;
+
+use Illuminate\Routing\Controller;
+
+class RoutingControllerOtherStub extends Controller
+{
+    public function find()
+    {
+        return 'baz';
+    }
+}


### PR DESCRIPTION
I've been tinkering with Lumen 5.2 and found that ```getIterableRoutes()``` on the Lumen adapter does not return the expected result in that version of Lumen. This is due to [FastRoute](https://github.com/nikic/FastRoute) being bumped from 0.4.0 in 5.1 to 0.7.0 in 5.2 where the route and the http verb was flipped when adding static routes.

I found no tests for this so I added one as a reminder when 5.2 gets supported.