### PR TITLE
Add support for JsonResponse in exception handler

### DIFF
--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -4,6 +4,7 @@ namespace Dingo\Api\Exception;
 
 use Exception;
 use ReflectionFunction;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
 use Dingo\Api\Contract\Debug\MessageBagErrors;
@@ -132,7 +133,7 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
             }
 
             if ($response = $handler($exception)) {
-                if (! $response instanceof Response) {
+                if (! $response instanceof Response && ! $response instanceof JsonResponse) {
                     $response = new Response($response, $this->getExceptionStatusCode($exception));
                 }
 

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -22,8 +22,6 @@ class LaravelServiceProvider extends DingoServiceProvider
 
         $this->publishes([realpath(__DIR__.'/../../config/api.php') => config_path('api.php')]);
 
-
-
         $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
 
         $this->app['Dingo\Api\Http\Middleware\Request']->mergeMiddlewares(
@@ -31,7 +29,6 @@ class LaravelServiceProvider extends DingoServiceProvider
         );
 
         $this->addRequestMiddlewareToBeginning($kernel);
-
 
         $this->app['events']->listen(RequestWasMatched::class, function (RequestWasMatched $event) {
             $this->replaceRouteDispatcher();
@@ -109,12 +106,12 @@ class LaravelServiceProvider extends DingoServiceProvider
      */
     protected function cloneLaravelRouter()
     {
-         $router = clone $this->app['router'];
+        $router = clone $this->app['router'];
 
-         $router->middleware('api.auth', 'Dingo\Api\Http\Middleware\Auth');
-         $router->middleware('api.throttle', 'Dingo\Api\Http\Middleware\RateLimit');
+        $router->middleware('api.auth', 'Dingo\Api\Http\Middleware\Auth');
+        $router->middleware('api.throttle', 'Dingo\Api\Http\Middleware\RateLimit');
 
-         return $router;
+        return $router;
     }
 
     /**


### PR DESCRIPTION
If the registered custom handler, return response with type of `JsonResponse`, it should return the response and not passed to newly generated `Response` class.

It would be better to check if the returned response from custom handler is instance of `Symfony\Component\HttpFoundation\Response` rather than `Illuminate\Http\Response` and `Illuminate\Http\JsonResponse`. But since the package don't depend on `symfony/http-foundation` I did not change it to symfony request class.