### PR TITLE
Adding ability to return content with http factory created - maintain compatability with ->item()

### DIFF
--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -35,14 +35,21 @@ class Factory
     /**
      * Respond with a created response and associate a location if provided.
      *
+     * @param object   $item
+     * @param object   $transformer
+     * @param array    $parameters
+     * @param \Closure $after
      * @param null|string $location
      *
      * @return \Dingo\Api\Http\Response
      */
-    public function created($location = null)
+    public function created($item, $transformer, array $parameters = [], Closure $after = null, $location = null)
     {
-        $response = new Response(null);
-        $response->setStatusCode(201);
+        $class = get_class($item);
+
+        $binding = $this->transformer->register($class, $transformer, $parameters, $after);
+
+        $response = new Response($item, 201, [], $binding);
 
         if (! is_null($location)) {
             $response->header('Location', $location);

--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -35,10 +35,10 @@ class Factory
     /**
      * Respond with a created response and associate a location if provided.
      *
-     * @param object   $item
-     * @param object   $transformer
-     * @param array    $parameters
-     * @param \Closure $after
+     * @param object      $item
+     * @param object      $transformer
+     * @param array       $parameters
+     * @param \Closure    $after
      * @param null|string $location
      *
      * @return \Dingo\Api\Http\Response


### PR DESCRIPTION
As per http://jsonapi.org/format/#crud-creating, the 201 Created status should response with a document containing the primary resource created.

Otherwise you should return 204 No Content.

This fork maintains compatibility with item() which seems desired to be when returning the primary resource. However, maybe for non-breaking changes, the PR here (#935) would be better?