### PR TITLE
Allow custom limiter when Dingo\Api\Contract\Http\RateLimit\Throttle also implements HasRateLimiter.

### DIFF
--- a/src/Contract/Http/RateLimit/HasRateLimiter.php
+++ b/src/Contract/Http/RateLimit/HasRateLimiter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dingo\Api\Contract\Http\RateLimit;
+
+use Dingo\Api\Http\Request;
+use Illuminate\Container\Container;
+
+interface HasRateLimiter
+{
+    /**
+     * Get rate limiter callable.
+     *
+     * @param \Illuminate\Container\Container $app
+     * @param \Dingo\Api\Http\Request         $request
+     *
+     * @return string
+     */
+    public function getRateLimiter(Container $app, Request $request);
+}

--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Dingo\Api\Http\RateLimit\Throttle\Route;
 use Dingo\Api\Contract\Http\RateLimit\Throttle;
+use Dingo\Api\Contract\Http\RateLimit\HasRateLimiter;
 
 class Handler
 {
@@ -92,7 +93,9 @@ class Handler
         // If the throttle instance is already set then we'll just carry on as
         // per usual.
         if ($this->throttle instanceof Throttle) {
-            //
+            if ($this->throttle instanceof HasRateLimiter) {
+                $this->setRateLimiter([$this->throttle, 'getRateLimiter']);
+            }
 
         // If the developer specified a certain amount of requests or expiration
         // time on a specific route then we'll always use the route specific


### PR DESCRIPTION
This would allow custom Throttle to define the rate limiter key resolver within the class (instead of declaring it globally). This would allow different Throttle to use different rate limiter key values.

Signed-off-by: crynobone <crynobone@gmail.com>