### PR TITLE
Use --prefer-dist option instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
       env: setup=stable
 
 install:
-  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
-  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-stable; fi
-  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-lowest --prefer-stable; fi
+  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-dist; fi
+  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
The API limit on git archives donwloads has been removed: https://github.com/composer/composer/issues/4884#issuecomment-195229989
Using `--prefer-dist` will then speed up Travis-CI builds

---

For comparison:

- `prefer-source`: https://travis-ci.org/dingo/api/builds/121425628
- `prefer-dist`: https://travis-ci.org/dingo/api/builds/121428663