### PR TITLE
Fix Disptacher "createRequest" method to use named routes

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -458,11 +458,11 @@ class Dispatcher
     {
         $parameters = array_merge($this->parameters, (array) $parameters);
 
-        $uri = $this->addPrefixToUri($uri);
-
         // If the URI does not have a scheme then we can assume that there it is not an
         // absolute URI, in this case we'll prefix the root requests path to the URI.
         if (! parse_url($uri, PHP_URL_SCHEME)) {
+            $uri = $this->addPrefixToUri($uri);
+
             $uri = rtrim($this->getRootRequest()->root(), '/').'/'.ltrim($uri, '/');
         }
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -539,7 +539,7 @@ class Dispatcher
 
             $response = $this->router->dispatch($request);
 
-            if (! $response->isSuccessful()) {
+            if (! $response->isSuccessful() && ! $response->isEmpty()) {
                 throw new InternalHttpException($response);
             } elseif (! $this->raw) {
                 $response = $response->getOriginalContent();

--- a/src/Exception/ResourceException.php
+++ b/src/Exception/ResourceException.php
@@ -55,6 +55,10 @@ class ResourceException extends HttpException implements MessageBagErrors
      */
     public function hasErrors()
     {
-        return ! $this->errors->isEmpty();
+        if ($this->errors instanceof MessageBag) {
+            return ! $this->errors->isEmpty();
+        }
+
+        return ! empty($this->errors);
     }
 }


### PR DESCRIPTION
Now we can use:

``` PHP
app('Dingo\Api\Dispatcher')->get(version('v1')->route('test'));
```

This also fixes issue: #678
