### PR TITLE
Enable accepting array of Rate Limitting Keys

### DIFF
--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -171,6 +171,7 @@ class Handler
                     return true;
                 }
             }
+
             return false;
         } else {
             return false;
@@ -237,6 +238,7 @@ class Handler
             foreach ($limiter as $eachLimiter) {
                 array_push($values, $this->cache->get($this->key($key, $eachLimiter)));
             }
+
             return $values;
         } else {
             return $this->cache->get($this->key($key, $limiter));

--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -235,7 +235,7 @@ class Handler
         $limiter = $this->getRateLimiter();
         if (is_array($limiter)) {
             foreach ($limiter as $eachLimiter) {
-                array_push($values , $this->cache->get($this->key($key, $eachLimiter)));
+                array_push($values, $this->cache->get($this->key($key, $eachLimiter)));
             }
             return $values;
         } else {

--- a/tests/Routing/Adapter/LaravelTest.php
+++ b/tests/Routing/Adapter/LaravelTest.php
@@ -6,7 +6,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Dingo\Api\Routing\Adapter\Laravel;
-use Illuminate\Routing\RouteCollection;
 
 class LaravelTest extends BaseAdapterTest
 {


### PR DESCRIPTION
This will allow adding multiple Rate Limiting Keys for throttling.
Trying to resolve #1002.

Usage in bootstrap:
```php
app('Dingo\Api\Http\RateLimit\Handler')->setRateLimiter(function ($app, $request) {

    $clientIP = 'IP' . $request->getClientIp();

    try {
        if ($user = $app['tymon.jwt.auth']->parseToken()->authenticate()) {
            $userID =  'ID' . $user->id; //obtain user ID if available.
        }
    //catch all possible exceptions otherwise request will not go though
    } catch (\Tymon\JWTAuth\Exceptions\TokenExpiredException $e) {
    } catch (\Tymon\JWTAuth\Exceptions\TokenInvalidException $e) {
    } catch (\Tymon\JWTAuth\Exceptions\TokenBlacklistedException $e) {
    } catch (\Tymon\JWTAuth\Exceptions\JWTException $e) {
    }

    if(isset($userID)){ //if user I available, return an array of strings.
        return array($clientIP, $userID);
    }else{ //if no user id available, just return a string.
        return $clientIP;
    }

});
```