### PR TITLE
Throttle groups

### DIFF
--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -330,7 +330,7 @@ class Handler
 
         $this->throttles->push($throttle);
     }
-    
+
     /**
      * Get the key prefix.
      *
@@ -339,10 +339,8 @@ class Handler
     public function getKeyPrefix()
     {
         if (method_exists($this->throttle, 'group') && $this->throttle->group()) {
-            
             return call_user_func($this->throttle->group(), $this->container, $this->request);
         } else {
-            
             return md5($this->request->path());
         }
     }

--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -103,8 +103,6 @@ class Handler
         } elseif ($limit > 0 || $expires > 0) {
             $this->throttle = new Route(['limit' => $limit, 'expires' => $expires]);
 
-            $this->keyPrefix = md5($request->path());
-
         // Otherwise we'll use the throttle that gives the consumer the largest
         // amount of requests. If no matching throttle is found then rate
         // limiting will not be imposed for the request.
@@ -119,6 +117,7 @@ class Handler
         }
 
         $this->prepareCacheStore();
+        $this->keyPrefix = $this->getKeyPrefix();
 
         $this->cache('requests', 0, $this->throttle->getExpires());
         $this->cache('expires', $this->throttle->getExpires(), $this->throttle->getExpires());
@@ -330,5 +329,21 @@ class Handler
         }
 
         $this->throttles->push($throttle);
+    }
+    
+    /**
+     * Get the key prefix.
+     *
+     * @return string
+     */
+    public function getKeyPrefix()
+    {
+        if (method_exists($this->throttle, 'group') && $this->throttle->group()) {
+            
+            return call_user_func($this->throttle->group(), $this->container, $this->request);
+        } else {
+            
+            return md5($this->request->path());
+        }
     }
 }

--- a/tests/Routing/Adapter/LaravelTest.php
+++ b/tests/Routing/Adapter/LaravelTest.php
@@ -6,7 +6,8 @@ use Illuminate\Routing\Router;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Dingo\Api\Routing\Adapter\Laravel;
-use Illuminate\Routing\RouteCollection;
+
+//use Illuminate\Routing\RouteCollection;
 
 class LaravelTest extends BaseAdapterTest
 {


### PR DESCRIPTION
Allow setting $keyPrefix so that custom throttles can be grouped conditionally.
Trying to resolve #1010 

``` php
<?php

use Illuminate\Container\Container;
use Dingo\Api\Http\RateLimit\Throttle\Throttle;

class ExampleThrottle extends Throttle
{

    /**
     * Example throttle will be matched unconditionally.
     *
     * @param \Illuminate\Container\Container $container
     *
     * @return bool
     */
    public function match(Container $app)
    {
        // Perform some logic here and return either true or false depending on whether
        // your conditions matched for the throttle.

        return true;
    }

    /**
     * Define throttle groups conditonally.
     *
     * @return void
     */
    public function group(){
        return function ($app, $request) {

            //return null to apply thottle globally
            return md5($request->path());
        };
    }
}
```
