### PR TITLE
Add extra conditions array to Basic auth provider

### DIFF
--- a/src/Auth/Provider/Basic.php
+++ b/src/Auth/Provider/Basic.php
@@ -24,17 +24,26 @@ class Basic extends Authorization
     protected $identifier;
 
     /**
+     * Extra conditions.
+     *
+     * @var array
+     */
+    private $extraConditions;
+
+    /**
      * Create a new basic provider instance.
      *
      * @param \Illuminate\Auth\AuthManager $auth
      * @param string                       $identifier
+     * @param array                        $extraConditions
      *
      * @return void
      */
-    public function __construct(AuthManager $auth, $identifier = 'email')
+    public function __construct(AuthManager $auth, $identifier = 'email', $extraConditions = [])
     {
         $this->auth = $auth;
         $this->identifier = $identifier;
+        $this->extraConditions = $extraConditions;
     }
 
     /**
@@ -49,7 +58,7 @@ class Basic extends Authorization
     {
         $this->validateAuthorizationHeader($request);
 
-        if (($response = $this->auth->onceBasic($this->identifier)) && $response->getStatusCode() === 401) {
+        if (($response = $this->auth->onceBasic($this->identifier, $this->extraConditions)) && $response->getStatusCode() === 401) {
             throw new UnauthorizedHttpException('Basic', 'Invalid authentication credentials.');
         }
 

--- a/tests/Auth/Provider/BasicTest.php
+++ b/tests/Auth/Provider/BasicTest.php
@@ -28,7 +28,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('GET', '/', [], [], [], ['HTTP_AUTHORIZATION' => 'Basic 12345']);
 
-        $this->auth->shouldReceive('onceBasic')->once()->with('email')->andReturn(new Response('', 401));
+        $this->auth->shouldReceive('onceBasic')->once()->with('email', [])->andReturn(new Response('', 401));
 
         $this->provider->authenticate($request, m::mock('Dingo\Api\Routing\Route'));
     }
@@ -37,7 +37,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('GET', '/', [], [], [], ['HTTP_AUTHORIZATION' => 'Basic 12345']);
 
-        $this->auth->shouldReceive('onceBasic')->once()->with('email')->andReturn(null);
+        $this->auth->shouldReceive('onceBasic')->once()->with('email', [])->andReturn(null);
         $this->auth->shouldReceive('user')->once()->andReturn('foo');
 
         $this->assertEquals('foo', $this->provider->authenticate($request, m::mock('Dingo\Api\Routing\Route')));


### PR DESCRIPTION
As the method `onceBasic` also take the `extraConditions` array as a parameter (https://github.com/laravel/framework/blob/5.2/src/Illuminate/Auth/SessionGuard.php#L289), I made the `Basic` provider be able to take the array too.
