### PR TITLE
Use $request->input() instead of $request->get()

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -161,7 +161,7 @@ class Fractal implements Adapter
      */
     public function parseFractalIncludes(Request $request)
     {
-        $includes = $request->get($this->includeKey);
+        $includes = $request->input($this->includeKey);
 
         if (! is_array($includes)) {
             $includes = array_filter(explode($this->includeSeparator, $includes));


### PR DESCRIPTION
`get()` cannot pick up Illuminate's JSON data input source, while `input()` does.

See this declined PR for the Laravel framework: https://github.com/laravel/framework/pull/13566