### PR TITLE
Allow override of eager load on transformer

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -116,7 +116,11 @@ class Fractal implements Adapter
         if ($response instanceof IlluminatePaginator) {
             $response = $response->getCollection();
         }
-
+        
+       if ($response instanceof EloquentCollection && method_exists($response->first(), 'apiEagerLoad')) {
+            $this->eagerLoading = (bool) $response->first()->apiEagerLoad();
+        }
+        
         return $response instanceof EloquentCollection && $this->eagerLoading;
     }
 


### PR DESCRIPTION
I have hunted through the docs and source code for this and seen some things that make me think this is available, however I was unable to find anyway to do it without a file change.

The idea of this is simple, if you have a collection that you do not want to eager load to disable it for just that transformer (or just that model).

The use case for me is that I have some polymorphic relations that need to get a related item from the related model. So if I use the transformer normally It will error as it tries to eager load when it needs to load an extra sub module. I can think of other ways around this (at the cost of verbosity) but I do see the use for being able to disable eager loading in some cases.

The way to use this is to just add a function in the model you are using for the transform and make a function called `apiEagerLoad` and return true or false. It will automatically check and use that function to override.

There is likely better ways to do this. I for one don't like targeting the first result to get to the model, probably adding extra parameters to collection/item that can trigger the `disableEagerLoad` function in the manager would be better. However I am not confident in my understanding of this package so I decided on the simplest solution to get my point across.