### PR TITLE
Use the bootstrapPath method if it exists

### DIFF
--- a/src/Console/Command/Cache.php
+++ b/src/Console/Command/Cache.php
@@ -83,7 +83,11 @@ class Cache extends Command
      */
     protected function getFreshApplication()
     {
-        $app = require $this->laravel->basePath().'/bootstrap/app.php';
+        if (method_exists($this->laravel, 'bootstrapPath')) {
+            $app = require $this->laravel->bootstrapPath().'/app.php';
+        } else {
+            $app = require $this->laravel->basePath().'/bootstrap/app.php';
+        }
 
         $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
 

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -88,7 +88,9 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
     public function testInternalRequestWithVersionAndParameters()
     {
         $this->router->version('v1', function () {
-            $this->router->get('test', function () { return 'test'; });
+            $this->router->get('test', function () {
+                return 'test';
+            });
         });
 
         $this->assertEquals('test', $this->dispatcher->version('v1')->with(['foo' => 'bar'])->get('test'));

--- a/tests/Routing/Adapter/LaravelTest.php
+++ b/tests/Routing/Adapter/LaravelTest.php
@@ -6,7 +6,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Dingo\Api\Routing\Adapter\Laravel;
-use Illuminate\Routing\RouteCollection;
 
 class LaravelTest extends BaseAdapterTest
 {


### PR DESCRIPTION
Laravel 5.2.23 introduced the bootstrapPath method in the Application container. In the event someone is using non-default paths (such as the bootstrap path), there’s no way to compile API routes using the built-in console job. This pull request checks to see if the bootstrapPath method exists and uses it if it does.
