### PR TITLE
Laravel 5.3 gatherRouteMiddlewares() change

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -139,7 +139,7 @@ class Request
         // middleware, so we'll gather all the route middleware here.
         // On Lumen this will simply be an empty array as it does
         // not implement terminable route middleware.
-        $middlewares = $this->gatherRouteMiddlewares($request);
+        $middlewares = $this->gatherRouteMiddleware($request);
 
         // Because of how middleware is executed on Lumen we'll need to merge in the
         // application middlewares now so that we can terminate them. Laravel does
@@ -187,10 +187,10 @@ class Request
      *
      * @return array
      */
-    protected function gatherRouteMiddlewares($request)
+    protected function gatherRouteMiddleware($request)
     {
         if ($route = $request->route()) {
-            return $this->router->gatherRouteMiddlewares($route);
+            return $this->router->gatherRouteMiddleware($route);
         }
 
         return [];

--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -224,9 +224,9 @@ class Laravel implements Adapter
      *
      * @return array
      */
-    public function gatherRouteMiddlewares($route)
+    public function gatherRouteMiddleware($route)
     {
-        return $this->router->gatherRouteMiddlewares($route);
+        return $this->router->gatherRouteMiddleware($route);
     }
 
     /**

--- a/src/Routing/Adapter/Lumen.php
+++ b/src/Routing/Adapter/Lumen.php
@@ -366,7 +366,7 @@ class Lumen implements Adapter
      *
      * @return array
      */
-    public function gatherRouteMiddlewares($route)
+    public function gatherRouteMiddleware($route)
     {
         // Route middleware in Lumen is not terminated.
         return [];

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -638,9 +638,9 @@ class Router
      *
      * @return array
      */
-    public function gatherRouteMiddlewares($route)
+    public function gatherRouteMiddleware($route)
     {
-        return $this->adapter->gatherRouteMiddlewares($route);
+        return $this->adapter->gatherRouteMiddleware($route);
     }
 
     /**


### PR DESCRIPTION
In Laravel 5.3, `gatherRouteMiddlewares()` in the `src/Illuminate/Routing/Router.php` has been changed to `gatherRouteMiddleware()`, causing API to fail. This PR is addressing that. Here's commit history on Router.php:
https://github.com/laravel/framework/commit/ce0d33d602f65a64ff531744b7058763823cbb00#diff-66c4eb54eb5af7de5e493b416e13991dL653