### PR TITLE
Trim spaces from include values if needed.

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -164,7 +164,7 @@ class Fractal implements Adapter
         $includes = $request->get($this->includeKey);
 
         if (! is_array($includes)) {
-            $includes = array_filter(explode($this->includeSeparator, $includes));
+            $includes = array_map('trim', array_filter(explode($this->includeSeparator, $includes)));
         }
 
         $this->fractal->parseIncludes($includes);

--- a/tests/Transformer/Adapter/FractalTest.php
+++ b/tests/Transformer/Adapter/FractalTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dingo\Api\Tests\Transformer\Adapter;
+
+use PHPUnit_Framework_TestCase;
+use Dingo\Api\Http\Request;
+use Dingo\Api\Transformer\Adapter\Fractal;
+use League\Fractal\Manager as FractalManager;
+
+class FractalTest extends PHPUnit_Framework_TestCase
+{
+    protected $fractal;
+
+    protected function setUp()
+    {
+        $this->fractal = new Fractal(new FractalManager());
+    }
+
+    public function testParseFractalIncludes()
+    {
+        $request = Request::create('/?include=foo,bar', 'GET');
+        $this->fractal->parseFractalIncludes($request);
+        $requestedIncludes = $this->fractal->getFractal()->getRequestedIncludes();
+
+        $this->assertEquals(['foo', 'bar'], $requestedIncludes);
+    }
+
+    public function testParseFractalIncludesWithSpaces()
+    {
+        $request = Request::create('/?include=foo, bar', 'GET');
+        $this->fractal->parseFractalIncludes($request);
+        $requestedIncludes = $this->fractal->getFractal()->getRequestedIncludes();
+
+        $this->assertEquals(['foo', 'bar'], $requestedIncludes);
+    }
+}


### PR DESCRIPTION
Just a thought but I think it would be nice if spaces around include values could be trimmed out if needed (eg. a request for `/?include=foo, bar` would treat " bar" as "bar"). This PR does just that, as well as adding a test class for Dingo\Api\Transformer\Adapter\Fractal
