### PR TITLE
rate limit: Limit should apply to all routes

### DIFF
--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -103,8 +103,6 @@ class Handler
         } elseif ($limit > 0 || $expires > 0) {
             $this->throttle = new Route(['limit' => $limit, 'expires' => $expires]);
 
-            $this->keyPrefix = md5($request->path());
-
         // Otherwise we'll use the throttle that gives the consumer the largest
         // amount of requests. If no matching throttle is found then rate
         // limiting will not be imposed for the request.
@@ -171,7 +169,7 @@ class Handler
      */
     protected function key($key)
     {
-        return sprintf('dingo.api.%s.%s.%s', $this->keyPrefix, $key, $this->getRateLimiter());
+        return sprintf('dingo.api.%s.%s', $key, $this->getRateLimiter());
     }
 
     /**


### PR DESCRIPTION
Exceeding the rate limit should return 403 for all further requests; the route of the request should not matter.

The current behavior is such that exceeding the rate limit will only 403 that particular route.