### PR TITLE
Fixed 500 error when requesting include that didn't exist

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -65,10 +65,10 @@ class Fractal implements Adapter
     /**
      * Transform a response with a transformer.
      *
-     * @param mixed                          $response
-     * @param TransformerAbstract|object     $transformer
-     * @param \Dingo\Api\Transformer\Binding $binding
-     * @param \Dingo\Api\Http\Request        $request
+     * @param mixed                                         $response
+     * @param League\Fractal\TransformerAbstract|object     $transformer
+     * @param \Dingo\Api\Transformer\Binding                $binding
+     * @param \Dingo\Api\Http\Request                       $request
      *
      * @return array
      */

--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -4,6 +4,7 @@ namespace Dingo\Api\Transformer\Adapter;
 
 use Dingo\Api\Http\Request;
 use Dingo\Api\Transformer\Binding;
+use League\Fractal\TransformerAbstract;
 use Dingo\Api\Contract\Transformer\Adapter;
 use League\Fractal\Manager as FractalManager;
 use League\Fractal\Resource\Item as FractalItem;
@@ -12,7 +13,6 @@ use Illuminate\Support\Collection as IlluminateCollection;
 use League\Fractal\Resource\Collection as FractalCollection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Contracts\Pagination\Paginator as IlluminatePaginator;
-use League\Fractal\TransformerAbstract;
 
 class Fractal implements Adapter
 {
@@ -66,7 +66,7 @@ class Fractal implements Adapter
      * Transform a response with a transformer.
      *
      * @param mixed                          $response
-     * @param object|TransformerAbstract     $transformer
+     * @param TransformerAbstract|object     $transformer
      * @param \Dingo\Api\Transformer\Binding $binding
      * @param \Dingo\Api\Http\Request        $request
      *

--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -90,7 +90,7 @@ class Fractal implements Adapter
         if ($this->shouldEagerLoad($response)) {
             $eagerLoads = $this->mergeEagerLoads($transformer, $this->fractal->getRequestedIncludes());
 
-            if($transformer instanceof TransformerAbstract){
+            if ($transformer instanceof TransformerAbstract) {
                 // Only eager load the items in available includes
                 $eagerLoads = array_intersect($eagerLoads, $transformer->getAvailableIncludes());
             }

--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -65,10 +65,10 @@ class Fractal implements Adapter
     /**
      * Transform a response with a transformer.
      *
-     * @param mixed                                         $response
-     * @param League\Fractal\TransformerAbstract|object     $transformer
-     * @param \Dingo\Api\Transformer\Binding                $binding
-     * @param \Dingo\Api\Http\Request                       $request
+     * @param mixed                                     $response
+     * @param League\Fractal\TransformerAbstract|object $transformer
+     * @param \Dingo\Api\Transformer\Binding            $binding
+     * @param \Dingo\Api\Http\Request                   $request
      *
      * @return array
      */

--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection as IlluminateCollection;
 use League\Fractal\Resource\Collection as FractalCollection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Contracts\Pagination\Paginator as IlluminatePaginator;
+use League\Fractal\TransformerAbstract;
 
 class Fractal implements Adapter
 {
@@ -65,7 +66,7 @@ class Fractal implements Adapter
      * Transform a response with a transformer.
      *
      * @param mixed                          $response
-     * @param object                         $transformer
+     * @param object|TransformerAbstract     $transformer
      * @param \Dingo\Api\Transformer\Binding $binding
      * @param \Dingo\Api\Http\Request        $request
      *
@@ -88,6 +89,11 @@ class Fractal implements Adapter
 
         if ($this->shouldEagerLoad($response)) {
             $eagerLoads = $this->mergeEagerLoads($transformer, $this->fractal->getRequestedIncludes());
+
+            if($transformer instanceof TransformerAbstract){
+                // Only eager load the items in available includes
+                $eagerLoads = array_intersect($eagerLoads, $transformer->getAvailableIncludes());
+            }
 
             $response->load($eagerLoads);
         }


### PR DESCRIPTION
- Error was caused by the eager loading functionality
- Fix was to check for available includes if possible before blindly using them as an eager load
- This fix will quietly ignore invalid includes. We should consider throwing a http exception as a better fix
