### PR TITLE
Allow internal requests via commands

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -462,8 +462,9 @@ class Dispatcher
 
         // If the URI does not have a scheme then we can assume that there it is not an
         // absolute URI, in this case we'll prefix the root requests path to the URI.
-        if (! parse_url($uri, PHP_URL_SCHEME)) {
-            $uri = rtrim($this->getRootRequest()->root(), '/').'/'.ltrim($uri, '/');
+        $rootUrl = $this->getRootRequest()->root();
+        if ((! parse_url($uri, PHP_URL_SCHEME)) && parse_url($rootUrl) !== false) {
+            $uri = rtrim($rootUrl, '/').'/'.ltrim($uri, '/');
         }
 
         $request = InternalRequest::create(


### PR DESCRIPTION
Currently internal requests can't be made from within a console command. When `$this->getRootRequest()->root()` runs it returns `http://:` because it is not able to resolve a host from `$_SERVER` (have a look at `Symfony\Component\HttpFoundation\Request@getHost`). This will prevent that from getting prefixed and allow requests from a console command.
