### PR TITLE
Use ::class notation to reference to classes

### DIFF
--- a/src/Console/Command/Cache.php
+++ b/src/Console/Command/Cache.php
@@ -4,6 +4,7 @@ namespace Dingo\Api\Console\Command;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Console\Kernel;
 
 class Cache extends Command
 {
@@ -85,7 +86,7 @@ class Cache extends Command
     {
         $app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $app->make(Kernel::class)->bootstrap();
 
         return $app;
     }

--- a/src/Http/RequestValidator.php
+++ b/src/Http/RequestValidator.php
@@ -3,6 +3,9 @@
 namespace Dingo\Api\Http;
 
 use Illuminate\Container\Container;
+use Dingo\Api\Http\Validation\Accept;
+use Dingo\Api\Http\Validation\Domain;
+use Dingo\Api\Http\Validation\Prefix;
 use Dingo\Api\Contract\Http\Validator;
 use Illuminate\Http\Request as IlluminateRequest;
 
@@ -21,8 +24,8 @@ class RequestValidator
      * @var array
      */
     protected $validators = [
-        'Dingo\Api\Http\Validation\Domain',
-        'Dingo\Api\Http\Validation\Prefix',
+        Domain::class,
+        Prefix::class,
     ];
 
     /**
@@ -96,7 +99,7 @@ class RequestValidator
         // been run. This ensures that we only run the accept validator once we know we
         // have a request that is targeting the API.
         if ($passed) {
-            $this->container->make('Dingo\Api\Http\Validation\Accept')->validate($request);
+            $this->container->make(Accept::class)->validate($request);
         }
 
         return $passed;

--- a/src/Provider/HttpServiceProvider.php
+++ b/src/Provider/HttpServiceProvider.php
@@ -2,10 +2,22 @@
 
 namespace Dingo\Api\Provider;
 
-use Dingo\Api\Http\Middleware;
+use Dingo\Api\Auth\Auth;
+use Dingo\Api\Routing\Router;
 use Dingo\Api\Http\Validation;
+use Dingo\Api\Http\Middleware;
+use Dingo\Api\Transformer\Factory;
 use Dingo\Api\Http\RequestValidator;
+use Dingo\Api\Http\RateLimit\Handler;
+use Dingo\Api\Http\Validation\Accept;
+use Dingo\Api\Http\Validation\Domain;
+use Dingo\Api\Http\Validation\Prefix;
+use Dingo\Api\Http\Middleware\Request;
+use Dingo\Api\Http\Middleware\RateLimit;
+use Dingo\Api\Contract\Debug\ExceptionHandler;
+use Dingo\Api\Http\Middleware\PrepareController;
 use Dingo\Api\Http\Parser\Accept as AcceptParser;
+use Dingo\Api\Http\Middleware\Auth as AuthMiddleware;
 use Dingo\Api\Http\Response\Factory as ResponseFactory;
 use Dingo\Api\Http\RateLimit\Handler as RateLimitHandler;
 
@@ -52,17 +64,17 @@ class HttpServiceProvider extends ServiceProvider
             return new RequestValidator($app);
         });
 
-        $this->app->singleton('Dingo\Api\Http\Validation\Domain', function ($app) {
+        $this->app->singleton(Domain::class, function ($app) {
             return new Validation\Domain($this->config('domain'));
         });
 
-        $this->app->singleton('Dingo\Api\Http\Validation\Prefix', function ($app) {
+        $this->app->singleton(Prefix::class, function ($app) {
             return new Validation\Prefix($this->config('prefix'));
         });
 
-        $this->app->singleton('Dingo\Api\Http\Validation\Accept', function ($app) {
+        $this->app->singleton(Accept::class, function ($app) {
             return new Validation\Accept(
-                $this->app['Dingo\Api\Http\Parser\Accept'],
+                $this->app[AcceptParser::class],
                 $this->config('strict')
             );
         });
@@ -75,7 +87,7 @@ class HttpServiceProvider extends ServiceProvider
      */
     protected function registerHttpParsers()
     {
-        $this->app->singleton('Dingo\Api\Http\Parser\Accept', function ($app) {
+        $this->app->singleton(AcceptParser::class, function ($app) {
             return new AcceptParser(
                 $this->config('standardsTree'),
                 $this->config('subtype'),
@@ -93,7 +105,7 @@ class HttpServiceProvider extends ServiceProvider
     protected function registerResponseFactory()
     {
         $this->app->singleton('api.http.response', function ($app) {
-            return new ResponseFactory($app['Dingo\Api\Transformer\Factory']);
+            return new ResponseFactory($app[Factory::class]);
         });
     }
 
@@ -104,12 +116,12 @@ class HttpServiceProvider extends ServiceProvider
      */
     protected function registerMiddleware()
     {
-        $this->app->singleton('Dingo\Api\Http\Middleware\Request', function ($app) {
+        $this->app->singleton(Request::class, function ($app) {
             $middleware = new Middleware\Request(
                 $app,
-                $app['Dingo\Api\Contract\Debug\ExceptionHandler'],
-                $app['Dingo\Api\Routing\Router'],
-                $app['Dingo\Api\Http\RequestValidator'],
+                $app[ExceptionHandler::class],
+                $app[Router::class],
+                $app[RequestValidator::class],
                 $app['events']
             );
 
@@ -118,16 +130,16 @@ class HttpServiceProvider extends ServiceProvider
             return $middleware;
         });
 
-        $this->app->singleton('Dingo\Api\Http\Middleware\Auth', function ($app) {
-            return new Middleware\Auth($app['Dingo\Api\Routing\Router'], $app['Dingo\Api\Auth\Auth']);
+        $this->app->singleton(AuthMiddleware::class, function ($app) {
+            return new Middleware\Auth($app[Router::class], $app[Auth::class]);
         });
 
-        $this->app->singleton('Dingo\Api\Http\Middleware\RateLimit', function ($app) {
-            return new Middleware\RateLimit($app['Dingo\Api\Routing\Router'], $app['Dingo\Api\Http\RateLimit\Handler']);
+        $this->app->singleton(RateLimit::class, function ($app) {
+            return new Middleware\RateLimit($app[Router::class], $app[Handler::class]);
         });
 
-        $this->app->singleton('Dingo\Api\Http\Middleware\PrepareController', function ($app) {
-            return new Middleware\PrepareController($app['Dingo\Api\Routing\Router']);
+        $this->app->singleton(PrepareController::class, function ($app) {
+            return new Middleware\PrepareController($app[Router::class]);
         });
     }
 }

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -3,10 +3,13 @@
 namespace Dingo\Api\Provider;
 
 use ReflectionClass;
-use Illuminate\Routing\Router;
+use Dingo\Api\Http\Middleware\Auth;
 use Illuminate\Contracts\Http\Kernel;
 use Dingo\Api\Event\RequestWasMatched;
+use Dingo\Api\Http\Middleware\Request;
+use Dingo\Api\Http\Middleware\RateLimit;
 use Illuminate\Routing\ControllerDispatcher;
+use Dingo\Api\Http\Middleware\PrepareController;
 use Dingo\Api\Routing\Adapter\Laravel as LaravelAdapter;
 
 class LaravelServiceProvider extends DingoServiceProvider
@@ -22,9 +25,9 @@ class LaravelServiceProvider extends DingoServiceProvider
 
         $this->publishes([realpath(__DIR__.'/../../config/api.php') => config_path('api.php')]);
 
-        $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
+        $kernel = $this->app->make(Kernel::class);
 
-        $this->app['Dingo\Api\Http\Middleware\Request']->mergeMiddlewares(
+        $this->app[Request::class]->mergeMiddlewares(
             $this->gatherAppMiddleware($kernel)
         );
 
@@ -36,9 +39,9 @@ class LaravelServiceProvider extends DingoServiceProvider
             $this->updateRouterBindings();
         });
 
-        $this->app['router']->middleware('api.auth', 'Dingo\Api\Http\Middleware\Auth');
-        $this->app['router']->middleware('api.throttle', 'Dingo\Api\Http\Middleware\RateLimit');
-        $this->app['router']->middleware('api.controllers', 'Dingo\Api\Http\Middleware\PrepareController');
+        $this->app['router']->middleware('api.auth', Auth::class);
+        $this->app['router']->middleware('api.throttle', RateLimit::class);
+        $this->app['router']->middleware('api.controllers', PrepareController::class);
     }
 
     /**
@@ -112,7 +115,7 @@ class LaravelServiceProvider extends DingoServiceProvider
      */
     protected function addRequestMiddlewareToBeginning(Kernel $kernel)
     {
-        $kernel->prependMiddleware('Dingo\Api\Http\Middleware\Request');
+        $kernel->prependMiddleware(Request::class);
     }
 
     /**

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -3,7 +3,13 @@
 namespace Dingo\Api\Provider;
 
 use ReflectionClass;
+use Dingo\Api\Http\Middleware\Auth;
+use Dingo\Api\Http\Middleware\Request;
+use Dingo\Api\Http\Middleware\RateLimit;
+use FastRoute\Dispatcher\GroupCountBased;
+use Dingo\Api\Http\Middleware\PrepareController;
 use FastRoute\RouteParser\Std as StdRouteParser;
+use Illuminate\Http\Request as IlluminateRequest;
 use Dingo\Api\Routing\Adapter\Lumen as LumenAdapter;
 use FastRoute\DataGenerator\GroupCountBased as GcbDataGenerator;
 
@@ -22,7 +28,7 @@ class LumenServiceProvider extends DingoServiceProvider
 
         $reflection = new ReflectionClass($this->app);
 
-        $this->app['Dingo\Api\Http\Middleware\Request']->mergeMiddlewares(
+        $this->app[Request::class]->mergeMiddlewares(
             $this->gatherAppMiddleware($reflection)
         );
 
@@ -31,7 +37,7 @@ class LumenServiceProvider extends DingoServiceProvider
         // Because Lumen sets the route resolver at a very weird point we're going to
         // have to use reflection whenever the request instance is rebound to
         // set the route resolver to get the current route.
-        $this->app->rebinding('Illuminate\Http\Request', function ($app, $request) {
+        $this->app->rebinding(IlluminateRequest::class, function ($app, $request) {
             $request->setRouteResolver(function () use ($app) {
                 $reflection = new ReflectionClass($app);
 
@@ -43,9 +49,9 @@ class LumenServiceProvider extends DingoServiceProvider
         });
 
         $this->app->routeMiddleware([
-            'api.auth' => 'Dingo\Api\Http\Middleware\Auth',
-            'api.throttle' => 'Dingo\Api\Http\Middleware\RateLimit',
-            'api.controllers' => 'Dingo\Api\Http\Middleware\PrepareController',
+            'api.auth' => Auth::class,
+            'api.throttle' => RateLimit::class,
+            'api.controllers' => PrepareController::class,
         ]);
     }
 
@@ -71,7 +77,7 @@ class LumenServiceProvider extends DingoServiceProvider
         parent::register();
 
         $this->app->singleton('api.router.adapter', function ($app) {
-            return new LumenAdapter($app, new StdRouteParser, new GcbDataGenerator, 'FastRoute\Dispatcher\GroupCountBased');
+            return new LumenAdapter($app, new StdRouteParser, new GcbDataGenerator, GroupCountBased::class);
         });
     }
 
@@ -90,7 +96,7 @@ class LumenServiceProvider extends DingoServiceProvider
 
         $middleware = $property->getValue($this->app);
 
-        array_unshift($middleware, 'Dingo\Api\Http\Middleware\Request');
+        array_unshift($middleware, Request::class);
 
         $property->setValue($this->app, $middleware);
         $property->setAccessible(false);

--- a/src/Provider/RoutingServiceProvider.php
+++ b/src/Provider/RoutingServiceProvider.php
@@ -4,7 +4,9 @@ namespace Dingo\Api\Provider;
 
 use Dingo\Api\Routing\Router;
 use Dingo\Api\Routing\UrlGenerator;
+use Dingo\Api\Contract\Routing\Adapter;
 use Dingo\Api\Routing\ResourceRegistrar;
+use Dingo\Api\Contract\Debug\ExceptionHandler;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -25,8 +27,8 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->singleton('api.router', function ($app) {
             $router = new Router(
-                $app['Dingo\Api\Contract\Routing\Adapter'],
-                $app['Dingo\Api\Contract\Debug\ExceptionHandler'],
+                $app[Adapter::class],
+                $app[ExceptionHandler::class],
                 $app,
                 $this->config('domain'),
                 $this->config('prefix')
@@ -37,8 +39,8 @@ class RoutingServiceProvider extends ServiceProvider
             return $router;
         });
 
-        $this->app->singleton('Dingo\Api\Routing\ResourceRegistrar', function ($app) {
-            return new ResourceRegistrar($app['Dingo\Api\Routing\Router']);
+        $this->app->singleton(ResourceRegistrar::class, function ($app) {
+            return new ResourceRegistrar($app[Router::class]);
         });
     }
 
@@ -50,7 +52,7 @@ class RoutingServiceProvider extends ServiceProvider
         $this->app->singleton('api.url', function ($app) {
             $url = new UrlGenerator($app['request']);
 
-            $url->setRouteCollections($app['Dingo\Api\Routing\Router']->getRoutes());
+            $url->setRouteCollections($app[Router::class]->getRoutes());
 
             return $url;
         });

--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -7,7 +7,6 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\RouteCollection;
 use Dingo\Api\Contract\Routing\Adapter;
-use Illuminate\Contracts\Container\Container;
 use Dingo\Api\Exception\UnknownVersionException;
 
 class Laravel implements Adapter

--- a/src/Routing/Helpers.php
+++ b/src/Routing/Helpers.php
@@ -3,6 +3,9 @@
 namespace Dingo\Api\Routing;
 
 use ErrorException;
+use Dingo\Api\Auth\Auth;
+use Dingo\Api\Dispatcher;
+use Dingo\Api\Http\Response\Factory;
 
 /**
  * @property \Dingo\Api\Dispatcher                                            $api
@@ -156,7 +159,7 @@ trait Helpers
      */
     public function api()
     {
-        return app('Dingo\Api\Dispatcher');
+        return app(Dispatcher::class);
     }
 
     /**
@@ -166,7 +169,7 @@ trait Helpers
      */
     protected function user()
     {
-        return app('Dingo\Api\Auth\Auth')->user();
+        return app(Auth::class)->user();
     }
 
     /**
@@ -176,7 +179,7 @@ trait Helpers
      */
     protected function auth()
     {
-        return app('Dingo\Api\Auth\Auth');
+        return app(Auth::class);
     }
 
     /**
@@ -186,7 +189,7 @@ trait Helpers
      */
     protected function response()
     {
-        return app('Dingo\Api\Http\Response\Factory');
+        return app(Factory::class);
     }
 
     /**

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -293,7 +293,7 @@ class Route
             $traits = array_merge(class_uses($trait, false), $traits);
         }
 
-        return isset($traits['Dingo\Api\Routing\Helpers']);
+        return isset($traits[Helpers::class]);
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -312,8 +312,8 @@ class Router
      */
     public function resource($name, $controller, array $options = [])
     {
-        if ($this->container->bound('Dingo\Api\Routing\ResourceRegistrar')) {
-            $registrar = $this->container->make('Dingo\Api\Routing\ResourceRegistrar');
+        if ($this->container->bound(ResourceRegistrar::class)) {
+            $registrar = $this->container->make(ResourceRegistrar::class);
         } else {
             $registrar = new ResourceRegistrar($this);
         }
@@ -505,7 +505,7 @@ class Router
     {
         $this->currentRoute = null;
 
-        $this->container->instance('Dingo\Api\Http\Request', $request);
+        $this->container->instance(Request::class, $request);
 
         $this->routesDispatched++;
 

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -5,8 +5,11 @@ namespace Dingo\Api\Tests\Auth;
 use Mockery as m;
 use Dingo\Api\Auth\Auth;
 use Dingo\Api\Http\Request;
+use Dingo\Api\Routing\Route;
+use Dingo\Api\Routing\Router;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Container\Container;
+use Dingo\Api\Contract\Auth\Provider;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
@@ -15,7 +18,7 @@ class AuthTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->container = new Container;
-        $this->router = m::mock('Dingo\Api\Routing\Router');
+        $this->router = m::mock(Router::class);
         $this->auth = new Auth($this->router, $this->container, []);
     }
 
@@ -29,10 +32,10 @@ class AuthTest extends PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownWhenAuthorizationHeaderNotSet()
     {
-        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock('Dingo\Api\Routing\Route'));
+        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock(Route::class));
         $this->router->shouldReceive('getCurrentRequest')->once()->andReturn($request = Request::create('foo', 'GET'));
 
-        $provider = m::mock('Dingo\Api\Auth\Provider\Provider');
+        $provider = m::mock(Provider::class);
         $provider->shouldReceive('authenticate')->once()->with($request, $route)->andThrow(new BadRequestHttpException);
 
         $this->auth->extend('provider', $provider);
@@ -45,10 +48,10 @@ class AuthTest extends PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownWhenProviderFailsToAuthenticate()
     {
-        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock('Dingo\Api\Routing\Route'));
+        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock(Route::class));
         $this->router->shouldReceive('getCurrentRequest')->once()->andReturn($request = Request::create('foo', 'GET'));
 
-        $provider = m::mock('Dingo\Api\Auth\Provider\Provider');
+        $provider = m::mock(Provider::class);
         $provider->shouldReceive('authenticate')->once()->with($request, $route)->andThrow(new UnauthorizedHttpException('foo'));
 
         $this->auth->extend('provider', $provider);
@@ -58,10 +61,10 @@ class AuthTest extends PHPUnit_Framework_TestCase
 
     public function testAuthenticationIsSuccessfulAndUserIsSet()
     {
-        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock('Dingo\Api\Routing\Route'));
+        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock(Route::class));
         $this->router->shouldReceive('getCurrentRequest')->once()->andReturn($request = Request::create('foo', 'GET'));
 
-        $provider = m::mock('Dingo\Api\Auth\Provider\Provider');
+        $provider = m::mock(Provider::class);
         $provider->shouldReceive('authenticate')->once()->with($request, $route)->andReturn((object) ['id' => 1]);
 
         $this->auth->extend('provider', $provider);
@@ -73,13 +76,13 @@ class AuthTest extends PHPUnit_Framework_TestCase
 
     public function testProvidersAreFilteredWhenSpecificProviderIsRequested()
     {
-        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock('Dingo\Api\Routing\Route'));
+        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn($route = m::mock(Route::class));
         $this->router->shouldReceive('getCurrentRequest')->once()->andReturn($request = Request::create('foo', 'GET'));
 
-        $provider = m::mock('Dingo\Api\Auth\Provider\Provider');
+        $provider = m::mock(Provider::class);
         $provider->shouldReceive('authenticate')->once()->with($request, $route)->andReturn((object) ['id' => 1]);
 
-        $this->auth->extend('one', m::mock('Dingo\Api\Auth\Provider\Provider'));
+        $this->auth->extend('one', m::mock(Provider::class));
         $this->auth->extend('two', $provider);
 
         $this->auth->authenticate(['two']);
@@ -91,7 +94,7 @@ class AuthTest extends PHPUnit_Framework_TestCase
         $this->router->shouldReceive('getCurrentRoute')->once()->andReturn('foo');
         $this->router->shouldReceive('getCurrentRequest')->once()->andReturn('bar');
 
-        $this->auth->extend('provider', m::mock('Dingo\Api\Auth\Provider\Provider'));
+        $this->auth->extend('provider', m::mock(Provider::class));
 
         $this->assertNull($this->auth->user());
     }

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -91,8 +91,8 @@ class AuthTest extends PHPUnit_Framework_TestCase
 
     public function testGettingUserWhenNotAuthenticatedAttemptsToAuthenticateAndReturnsNull()
     {
-        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn('foo');
-        $this->router->shouldReceive('getCurrentRequest')->once()->andReturn('bar');
+        $this->router->shouldReceive('getCurrentRoute')->once()->andReturn(m::mock(Route::class));
+        $this->router->shouldReceive('getCurrentRequest')->once()->andReturn(Request::create('foo', 'GET'));
 
         $this->auth->extend('provider', m::mock(Provider::class));
 

--- a/tests/Auth/Provider/AuthorizationTest.php
+++ b/tests/Auth/Provider/AuthorizationTest.php
@@ -3,6 +3,7 @@
 namespace Dingo\Api\Tests\Auth\Provider;
 
 use Mockery as m;
+use Dingo\Api\Routing\Route;
 use Illuminate\Http\Request;
 use PHPUnit_Framework_TestCase;
 use Dingo\Api\Tests\Stubs\AuthorizationProviderStub;
@@ -21,6 +22,6 @@ class AuthorizationTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('GET', '/');
 
-        (new AuthorizationProviderStub)->authenticate($request, m::mock('Dingo\Api\Routing\Route'));
+        (new AuthorizationProviderStub)->authenticate($request, m::mock(Route::class));
     }
 }

--- a/tests/Auth/Provider/OAuth2Test.php
+++ b/tests/Auth/Provider/OAuth2Test.php
@@ -3,15 +3,19 @@
 namespace Dingo\Api\Tests\Auth\Provider;
 
 use Mockery as m;
+use Dingo\Api\Routing\Route;
 use Illuminate\Http\Request;
 use PHPUnit_Framework_TestCase;
 use Dingo\Api\Auth\Provider\OAuth2;
+use League\OAuth2\Server\ResourceServer;
+use League\OAuth2\Server\Entity\SessionEntity;
+use League\OAuth2\Server\Entity\AccessTokenEntity;
 
 class OAuth2Test extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->server = m::mock('League\OAuth2\Server\ResourceServer');
+        $this->server = m::mock(ResourceServer::class);
         $this->provider = new OAuth2($this->server, false);
     }
 
@@ -29,12 +33,12 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
 
         $this->server->shouldReceive('isValidRequest')->once()->andReturn(true);
 
-        $token = m::mock('League\OAuth2\Server\Entity\AccessTokenEntity');
+        $token = m::mock(AccessTokenEntity::class);
         $token->shouldReceive('hasScope')->once()->with('foo')->andReturn(false);
 
         $this->server->shouldReceive('getAccessToken')->once()->andReturn($token);
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('scopes')->once()->andReturn(['foo']);
         $route->shouldReceive('scopeStrict')->once()->andReturn(false);
 
@@ -47,11 +51,11 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
 
         $this->server->shouldReceive('isValidRequest')->once()->andReturn(true);
 
-        $token = m::mock('League\OAuth2\Server\Entity\AccessTokenEntity');
+        $token = m::mock(AccessTokenEntity::class);
         $token->shouldReceive('hasScope')->once()->with('foo')->andReturn(true);
         $this->server->shouldReceive('getAccessToken')->once()->andReturn($token);
 
-        $session = m::mock('League\OAuth2\Server\Entity\SessionEntity');
+        $session = m::mock(SessionEntity::class);
         $token->shouldReceive('getSession')->once()->andReturn($session);
 
         $session->shouldReceive('getOwnerType')->once()->andReturn('client');
@@ -61,7 +65,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             //
         });
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('scopes')->once()->andReturn(['foo', 'bar']);
         $route->shouldReceive('scopeStrict')->once()->andReturn(false);
 
@@ -77,7 +81,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
 
         $this->server->shouldReceive('isValidRequest')->once()->andReturn(true);
 
-        $token = m::mock('League\OAuth2\Server\Entity\AccessTokenEntity');
+        $token = m::mock(AccessTokenEntity::class);
         $token->shouldReceive('hasScope')->once()->with('foo')->andReturn(true);
         $token->shouldReceive('hasScope')->once()->with('bar')->andReturn(false);
         $this->server->shouldReceive('getAccessToken')->once()->andReturn($token);
@@ -86,7 +90,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             //
         });
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('scopes')->once()->andReturn(['foo', 'bar']);
         $route->shouldReceive('scopeStrict')->once()->andReturn(true);
 
@@ -99,10 +103,10 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
 
         $this->server->shouldReceive('isValidRequest')->once()->andReturn(true);
 
-        $token = m::mock('League\OAuth2\Server\Entity\AccessTokenEntity');
+        $token = m::mock(AccessTokenEntity::class);
         $this->server->shouldReceive('getAccessToken')->once()->andReturn($token);
 
-        $session = m::mock('League\OAuth2\Server\Entity\SessionEntity');
+        $session = m::mock(SessionEntity::class);
         $token->shouldReceive('getSession')->once()->andReturn($session);
 
         $session->shouldReceive('getOwnerType')->once()->andReturn('client');
@@ -112,7 +116,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             return 'foo';
         });
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('scopes')->once()->andReturn([]);
         $route->shouldReceive('scopeStrict')->once()->andReturn(false);
 
@@ -125,10 +129,10 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
 
         $this->server->shouldReceive('isValidRequest')->once()->andReturn(true);
 
-        $token = m::mock('League\OAuth2\Server\Entity\AccessTokenEntity');
+        $token = m::mock(AccessTokenEntity::class);
         $this->server->shouldReceive('getAccessToken')->once()->andReturn($token);
 
-        $session = m::mock('League\OAuth2\Server\Entity\SessionEntity');
+        $session = m::mock(SessionEntity::class);
         $token->shouldReceive('getSession')->once()->andReturn($session);
 
         $session->shouldReceive('getOwnerType')->once()->andReturn('user');
@@ -138,7 +142,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             return 'foo';
         });
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('scopes')->once()->andReturn([]);
         $route->shouldReceive('scopeStrict')->once()->andReturn(false);
 

--- a/tests/Http/Middleware/AuthTest.php
+++ b/tests/Http/Middleware/AuthTest.php
@@ -3,11 +3,13 @@
 namespace Dingo\Api\Tests\Http\Middleware;
 
 use Mockery as m;
+use Dingo\Api\Auth\Auth;
 use Dingo\Api\Http\Request;
 use Dingo\Api\Routing\Route;
+use Dingo\Api\Routing\Router;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Container\Container;
-use Dingo\Api\Http\Middleware\Auth;
+use Dingo\Api\Http\Middleware\Auth as AuthMiddleware;
 use Dingo\Api\Tests\Stubs\RoutingAdapterStub;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
@@ -17,9 +19,9 @@ class AuthTest extends PHPUnit_Framework_TestCase
     {
         $this->container = new Container;
         $this->adapter = new RoutingAdapterStub;
-        $this->router = m::mock('Dingo\Api\Routing\Router');
-        $this->auth = m::mock('Dingo\Api\Auth\Auth');
-        $this->middleware = new Auth($this->router, $this->auth);
+        $this->router = m::mock(Router::class);
+        $this->auth = m::mock(Auth::class);
+        $this->middleware = new AuthMiddleware($this->router, $this->auth);
     }
 
     public function testProtectedRouteFiresAuthenticationAndPasses()

--- a/tests/Http/Middleware/RateLimitTest.php
+++ b/tests/Http/Middleware/RateLimitTest.php
@@ -5,6 +5,8 @@ namespace Dingo\Api\Tests\Http\Middleware;
 use Mockery as m;
 use Dingo\Api\Http\Request;
 use Dingo\Api\Http\Response;
+use Dingo\Api\Routing\Route;
+use Dingo\Api\Routing\Router;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Cache\CacheManager;
 use Dingo\Api\Http\InternalRequest;
@@ -21,7 +23,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
         $this->container = new Container;
         $this->container['config'] = ['cache.default' => 'array', 'cache.stores.array' => ['driver' => 'array']];
 
-        $this->router = m::mock('Dingo\Api\Routing\Router');
+        $this->router = m::mock(Router::class);
         $this->cache = new CacheManager($this->container);
         $this->handler = new Handler($this->container, $this->cache, []);
         $this->middleware = new RateLimit($this->router, $this->handler);
@@ -40,7 +42,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('test', 'GET');
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('hasThrottle')->once()->andReturn(false);
         $route->shouldReceive('getRateLimit')->once()->andReturn(0);
         $route->shouldReceive('getRateLimitExpiration')->once()->andReturn(0);
@@ -63,7 +65,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
     {
         $request = InternalRequest::create('test', 'GET');
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('hasThrottle')->never();
         $route->shouldReceive('getRateLimit')->never();
         $route->shouldReceive('getRateLimitExpiration')->never();
@@ -86,7 +88,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('test', 'GET');
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('hasThrottle')->once()->andReturn(false);
         $route->shouldReceive('getRateLimit')->once()->andReturn(0);
         $route->shouldReceive('getRateLimitExpiration')->once()->andReturn(0);
@@ -109,7 +111,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('test', 'GET');
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('hasThrottle')->once()->andReturn(false);
         $route->shouldReceive('getRateLimit')->once()->andReturn(0);
         $route->shouldReceive('getRateLimitExpiration')->once()->andReturn(0);
@@ -135,7 +137,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('test', 'GET');
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('hasThrottle')->once()->andReturn(false);
         $route->shouldReceive('getRateLimit')->once()->andReturn(5);
         $route->shouldReceive('getRateLimitExpiration')->once()->andReturn(10);
@@ -157,7 +159,7 @@ class RateLimitTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('test', 'GET');
 
-        $route = m::mock('Dingo\Api\Routing\Route');
+        $route = m::mock(Route::class);
         $route->shouldReceive('hasThrottle')->once()->andReturn(true);
         $route->shouldReceive('getThrottle')->once()->andReturn(new ThrottleStub(['limit' => 10, 'expires' => 20]));
         $route->shouldReceive('getRateLimit')->once()->andReturn(0);

--- a/tests/Http/Middleware/RequestTest.php
+++ b/tests/Http/Middleware/RequestTest.php
@@ -3,13 +3,20 @@
 namespace Dingo\Api\Tests\Http\Middleware;
 
 use Mockery as m;
-use Illuminate\Http\Request;
+use Dingo\Api\Http\Request;
+use Dingo\Api\Routing\Router;
 use Dingo\Api\Http\Validation;
 use PHPUnit_Framework_TestCase;
+use Dingo\Api\Exception\Handler;
+use Dingo\Api\Http\Validation\Accept;
+use Dingo\Api\Http\Validation\Domain;
+use Dingo\Api\Http\Validation\Prefix;
 use Dingo\Api\Http\RequestValidator;
 use Dingo\Api\Tests\Stubs\ApplicationStub;
 use Dingo\Api\Http\Parser\Accept as AcceptParser;
+use Illuminate\Http\Request as IlluminateRequest;
 use Illuminate\Events\Dispatcher as EventDispatcher;
+use Dingo\Api\Contract\Http\Request as RequestContract;
 use Dingo\Api\Http\Middleware\Request as RequestMiddleware;
 
 class RequestTest extends PHPUnit_Framework_TestCase
@@ -17,12 +24,12 @@ class RequestTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->app = new ApplicationStub;
-        $this->router = m::mock('Dingo\Api\Routing\Router');
+        $this->router = m::mock(Router::class);
         $this->validator = new RequestValidator($this->app);
-        $this->handler = m::mock('Dingo\Api\Exception\Handler');
+        $this->handler = m::mock(Handler::class);
         $this->events = new EventDispatcher($this->app);
 
-        $this->app->alias('Dingo\Api\Http\Request', 'Dingo\Api\Contract\Http\Request');
+        $this->app->alias(Request::class, RequestContract::class);
 
         $this->middleware = new RequestMiddleware($this->app, $this->handler, $this->router, $this->validator, $this->events);
     }
@@ -34,9 +41,9 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testNoPrefixOrDomainDoesNotMatch()
     {
-        $this->app['Dingo\Api\Http\Validation\Domain'] = new Validation\Domain(null);
-        $this->app['Dingo\Api\Http\Validation\Prefix'] = new Validation\Prefix(null);
-        $this->app['Dingo\Api\Http\Validation\Accept'] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
+        $this->app[Domain::class] = new Validation\Domain(null);
+        $this->app[Prefix::class] = new Validation\Prefix(null);
+        $this->app[Accept::class] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
 
         $request = Request::create('foo', 'GET');
 
@@ -47,23 +54,11 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testPrefixMatchesAndSendsRequestThroughRouter()
     {
-        $this->app['Dingo\Api\Http\Validation\Domain'] = new Validation\Domain(null);
-        $this->app['Dingo\Api\Http\Validation\Prefix'] = new Validation\Prefix('/');
-        $this->app['Dingo\Api\Http\Validation\Accept'] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
+        $this->app[Domain::class] = new Validation\Domain(null);
+        $this->app[Prefix::class] = new Validation\Prefix('/');
+        $this->app[Accept::class] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
 
-        $request = Request::create('foo', 'GET');
-
-        $this->router->shouldReceive('dispatch')->once();
-
-        $this->middleware->handle($request, function () {
-            //
-        });
-
-        $this->app['Dingo\Api\Http\Validation\Domain'] = new Validation\Domain(null);
-        $this->app['Dingo\Api\Http\Validation\Prefix'] = new Validation\Prefix('bar');
-        $this->app['Dingo\Api\Http\Validation\Accept'] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
-
-        $request = Request::create('bar/foo', 'GET');
+        $request = IlluminateRequest::create('foo', 'GET');
 
         $this->router->shouldReceive('dispatch')->once();
 
@@ -71,7 +66,19 @@ class RequestTest extends PHPUnit_Framework_TestCase
             //
         });
 
-        $request = Request::create('bing/bar/foo', 'GET');
+        $this->app[Domain::class] = new Validation\Domain(null);
+        $this->app[Prefix::class] = new Validation\Prefix('bar');
+        $this->app[Accept::class] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
+
+        $request = IlluminateRequest::create('bar/foo', 'GET');
+
+        $this->router->shouldReceive('dispatch')->once();
+
+        $this->middleware->handle($request, function () {
+            //
+        });
+
+        $request = IlluminateRequest::create('bing/bar/foo', 'GET');
 
         $this->middleware->handle($request, function ($handled) use ($request) {
             $this->assertSame($handled, $request);
@@ -80,11 +87,11 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testDomainMatchesAndSendsRequestThroughRouter()
     {
-        $this->app['Dingo\Api\Http\Validation\Domain'] = new Validation\Domain('foo.bar');
-        $this->app['Dingo\Api\Http\Validation\Prefix'] = new Validation\Prefix(null);
-        $this->app['Dingo\Api\Http\Validation\Accept'] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
+        $this->app[Domain::class] = new Validation\Domain('foo.bar');
+        $this->app[Prefix::class] = new Validation\Prefix(null);
+        $this->app[Accept::class] = new Validation\Accept(new AcceptParser('vnd', 'api', 'v1', 'json'));
 
-        $request = Request::create('http://foo.bar/baz', 'GET');
+        $request = IlluminateRequest::create('http://foo.bar/baz', 'GET');
 
         $this->router->shouldReceive('dispatch')->once();
 
@@ -92,7 +99,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             //
         });
 
-        $request = Request::create('http://bing.foo.bar/baz', 'GET');
+        $request = IlluminateRequest::create('http://bing.foo.bar/baz', 'GET');
 
         $this->middleware->handle($request, function ($handled) use ($request) {
             $this->assertSame($handled, $request);

--- a/tests/Http/RateLimit/HandlerTest.php
+++ b/tests/Http/RateLimit/HandlerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Cache\CacheManager;
 use Illuminate\Container\Container;
 use Dingo\Api\Http\RateLimit\Handler;
 use Dingo\Api\Tests\Stubs\ThrottleStub;
+use Dingo\Api\Http\RateLimit\Throttle\Route;
 
 class HandlerTest extends PHPUnit_Framework_TestCase
 {
@@ -30,7 +31,7 @@ class HandlerTest extends PHPUnit_Framework_TestCase
 
         $throttle = $this->limiter->getThrottle();
 
-        $this->assertInstanceOf('Dingo\Api\Http\RateLimit\Throttle\Route', $throttle);
+        $this->assertInstanceOf(Route::class, $throttle);
         $this->assertSame(100, $throttle->getLimit());
         $this->assertSame(100, $throttle->getExpires());
     }

--- a/tests/Http/RateLimit/Throttle/AuthenticatedTest.php
+++ b/tests/Http/RateLimit/Throttle/AuthenticatedTest.php
@@ -3,6 +3,7 @@
 namespace Dingo\Api\Tests\Http\RateLimit\Throttle;
 
 use Mockery;
+use Dingo\Api\Auth\Auth;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Container\Container;
 use Dingo\Api\Http\RateLimit\Throttle\Authenticated;
@@ -11,7 +12,7 @@ class AuthenticatedTest extends PHPUnit_Framework_TestCase
 {
     public function testThrottleMatchesCorrectly()
     {
-        $auth = Mockery::mock('Dingo\Api\Auth\Auth')->shouldReceive('check')->once()->andReturn(true)->getMock();
+        $auth = Mockery::mock(Auth::class)->shouldReceive('check')->once()->andReturn(true)->getMock();
         $container = new Container;
         $container['api.auth'] = $auth;
 

--- a/tests/Http/RateLimit/Throttle/UnauthenticatedTest.php
+++ b/tests/Http/RateLimit/Throttle/UnauthenticatedTest.php
@@ -3,6 +3,7 @@
 namespace Dingo\Api\Tests\Http\RateLimit\Throttle;
 
 use Mockery;
+use Dingo\Api\Auth\Auth;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Container\Container;
 use Dingo\Api\Http\RateLimit\Throttle\Unauthenticated;
@@ -11,7 +12,7 @@ class UnauthenticatedTest extends PHPUnit_Framework_TestCase
 {
     public function testThrottleMatchesCorrectly()
     {
-        $auth = Mockery::mock('Dingo\Api\Auth\Auth')->shouldReceive('check')->once()->andReturn(true)->getMock();
+        $auth = Mockery::mock(Auth::class)->shouldReceive('check')->once()->andReturn(true)->getMock();
         $container = new Container;
         $container['api.auth'] = $auth;
 

--- a/tests/Http/RequestValidatorTest.php
+++ b/tests/Http/RequestValidatorTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Container\Container;
 use Dingo\Api\Http\RequestValidator;
+use Dingo\Api\Tests\Stubs\HttpValidatorStub;
 use Dingo\Api\Http\Parser\Accept as AcceptParser;
 
 class RequestValidatorTest extends PHPUnit_Framework_TestCase
@@ -13,7 +14,7 @@ class RequestValidatorTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->container = new Container;
-        $this->container->instance('Dingo\Api\Http\Parser\Accept', new AcceptParser('vnd', 'test', 'v1', 'json'));
+        $this->container->instance(AcceptParser::class, new AcceptParser('vnd', 'test', 'v1', 'json'));
         $this->validator = new RequestValidator($this->container);
     }
 
@@ -26,14 +27,14 @@ class RequestValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidationFails()
     {
-        $this->validator->replace(['Dingo\Api\Tests\Stubs\HttpValidatorStub']);
+        $this->validator->replace([HttpValidatorStub::class]);
 
         $this->assertFalse($this->validator->validateRequest(Request::create('foo', 'GET')), 'Validation passed when given a GET request.');
     }
 
     public function testValidationPasses()
     {
-        $this->validator->replace(['Dingo\Api\Tests\Stubs\HttpValidatorStub']);
+        $this->validator->replace([HttpValidatorStub::class]);
 
         $this->assertTrue($this->validator->validateRequest(Request::create('foo', 'POST')), 'Validation failed when given a POST request.');
     }

--- a/tests/Http/Response/FactoryTest.php
+++ b/tests/Http/Response/FactoryTest.php
@@ -8,12 +8,13 @@ use Illuminate\Support\Collection;
 use Dingo\Api\Tests\Stubs\UserStub;
 use Dingo\Api\Http\Response\Factory;
 use Illuminate\Pagination\Paginator;
+use Dingo\Api\Transformer\Factory as TransformerFactory;
 
 class FactoryTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->transformer = Mockery::mock('Dingo\Api\Transformer\Factory');
+        $this->transformer = Mockery::mock(TransformerFactory::class);
         $this->factory = new Factory($this->transformer);
     }
 
@@ -70,10 +71,10 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
     public function testMakingCollectionRegistersUnderlyingClassWithTransformer()
     {
-        $this->transformer->shouldReceive('register')->twice()->with('Dingo\Api\Tests\Stubs\UserStub', 'test', [], null);
+        $this->transformer->shouldReceive('register')->twice()->with(UserStub::class, 'test', [], null);
 
-        $this->assertInstanceOf('Illuminate\Support\Collection', $this->factory->collection(new Collection([new UserStub('Jason')]), 'test')->getOriginalContent());
-        $this->assertInstanceOf('Illuminate\Support\Collection', $this->factory->withCollection(new Collection([new UserStub('Jason')]), 'test')->getOriginalContent());
+        $this->assertInstanceOf(Collection::class, $this->factory->collection(new Collection([new UserStub('Jason')]), 'test')->getOriginalContent());
+        $this->assertInstanceOf(Collection::class, $this->factory->withCollection(new Collection([new UserStub('Jason')]), 'test')->getOriginalContent());
     }
 
     public function testMakingCollectionResponseWithThreeParameters()
@@ -94,10 +95,10 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
     public function testMakingItemsRegistersClassWithTransformer()
     {
-        $this->transformer->shouldReceive('register')->twice()->with('Dingo\Api\Tests\Stubs\UserStub', 'test', [], null);
+        $this->transformer->shouldReceive('register')->twice()->with(UserStub::class, 'test', [], null);
 
-        $this->assertInstanceOf('Dingo\Api\Tests\Stubs\UserStub', $this->factory->item(new UserStub('Jason'), 'test')->getOriginalContent());
-        $this->assertInstanceOf('Dingo\Api\Tests\Stubs\UserStub', $this->factory->withItem(new UserStub('Jason'), 'test')->getOriginalContent());
+        $this->assertInstanceOf(UserStub::class, $this->factory->item(new UserStub('Jason'), 'test')->getOriginalContent());
+        $this->assertInstanceOf(UserStub::class, $this->factory->withItem(new UserStub('Jason'), 'test')->getOriginalContent());
     }
 
     public function testMakingItemResponseWithThreeParameters()
@@ -118,10 +119,10 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
     public function testMakingPaginatorRegistersUnderlyingClassWithTransformer()
     {
-        $this->transformer->shouldReceive('register')->twice()->with('Dingo\Api\Tests\Stubs\UserStub', 'test', [], null);
+        $this->transformer->shouldReceive('register')->twice()->with(UserStub::class, 'test', [], null);
 
-        $this->assertInstanceOf('Illuminate\Pagination\Paginator', $this->factory->paginator(new Paginator([new UserStub('Jason')], 1), 'test')->getOriginalContent());
-        $this->assertInstanceOf('Illuminate\Pagination\Paginator', $this->factory->withPaginator(new Paginator([new UserStub('Jason')], 1), 'test')->getOriginalContent());
+        $this->assertInstanceOf(Paginator::class, $this->factory->paginator(new Paginator([new UserStub('Jason')], 1), 'test')->getOriginalContent());
+        $this->assertInstanceOf(Paginator::class, $this->factory->withPaginator(new Paginator([new UserStub('Jason')], 1), 'test')->getOriginalContent());
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -7,6 +7,9 @@ use Mockery as m;
 use Dingo\Api\Http\Response;
 use PHPUnit_Framework_TestCase;
 use Dingo\Api\Transformer\Binding;
+use Illuminate\Container\Container;
+use Dingo\Api\Event\ResponseIsMorphing;
+use Dingo\Api\Event\ResponseWasMorphed;
 use Dingo\Api\Http\Response\Format\Json;
 use Illuminate\Events\Dispatcher as EventDispatcher;
 
@@ -44,7 +47,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testAddingAndSettingMetaCallsUnderlyingTransformerBinding()
     {
-        $binding = new Binding(m::mock('Illuminate\Container\Container'), 'foo');
+        $binding = new Binding(m::mock(Container::class), 'foo');
 
         $response = new Response('test', 200, [], $binding);
         $response->setMeta(['foo' => 'bar']);
@@ -65,7 +68,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testChangingContentWithEvents()
     {
-        $this->events->listen('Dingo\Api\Event\ResponseWasMorphed', function ($event) {
+        $this->events->listen(ResponseWasMorphed::class, function ($event) {
             $event->content['foo'] = 'bam!';
         });
 
@@ -75,12 +78,12 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame('{"foo":"bam!"}', $response->morph('json')->getContent());
 
-        $this->events->forget('Dingo\Api\Event\ResponseWasMorphed');
+        $this->events->forget(ResponseWasMorphed::class);
     }
 
     public function testChangingResponseHeadersWithEvents()
     {
-        $this->events->listen('Dingo\Api\Event\ResponseIsMorphing', function ($event) {
+        $this->events->listen(ResponseIsMorphing::class, function ($event) {
             $event->response->headers->set('x-foo', 'bar');
         });
 
@@ -90,6 +93,6 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame('bar', $response->morph('json')->headers->get('x-foo'));
 
-        $this->events->forget('Dingo\Api\Event\ResponseIsMorphing');
+        $this->events->forget(ResponseIsMorphing::class);
     }
 }

--- a/tests/Http/Validation/AcceptTest.php
+++ b/tests/Http/Validation/AcceptTest.php
@@ -4,8 +4,8 @@ namespace Dingo\Api\Tests\Http\Validation;
 
 use Illuminate\Http\Request;
 use PHPUnit_Framework_TestCase;
-use Dingo\Api\Http\Validation\Accept as AcceptValidator;
 use Dingo\Api\Http\Parser\Accept as AcceptParser;
+use Dingo\Api\Http\Validation\Accept as AcceptValidator;
 
 class AcceptTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/Routing/Adapter/LumenTest.php
+++ b/tests/Routing/Adapter/LumenTest.php
@@ -2,6 +2,7 @@
 
 namespace Dingo\Api\Tests\Routing\Adapter;
 
+use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
 use Dingo\Api\Routing\Adapter\Lumen;
 use FastRoute\RouteParser\Std as StdRouteParser;
@@ -21,7 +22,7 @@ class LumenTest extends BaseAdapterTest
         // from the Lumen request instance and set it on our request so we can fetch
         // the route properly.
         $this->container->rebinding('request', function ($app, $request) {
-            $request->setRouteResolver($app['Illuminate\Http\Request']->getRouteResolver());
+            $request->setRouteResolver($app[Request::class]->getRouteResolver());
         });
 
         return new Lumen($this->container, new StdRouteParser, new GcbDataGenerator, GcbDispatcher::class);

--- a/tests/Stubs/RoutingControllerStub.php
+++ b/tests/Stubs/RoutingControllerStub.php
@@ -18,7 +18,7 @@ class RoutingControllerStub extends Controller
 
         $this->rateLimit(10, 20);
 
-        $this->throttle('Dingo\Api\Tests\Stubs\BasicThrottleStub');
+        $this->throttle(BasicThrottleStub::class);
     }
 
     public function index()


### PR DESCRIPTION
Use `::class` notation to reference to classes

Integrates original commits  https://github.com/dingo/api/pull/1009 and replace it