### PR TITLE
FIX #1220 Closure middleware: explode() expects parameter 2 to be string, object given

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -150,6 +150,10 @@ class Request
         }
 
         foreach ($middlewares as $middleware) {
+            if ($middleware instanceof Closure) {
+                continue;
+            }
+
             list($name, $parameters) = $this->parseMiddleware($middleware);
 
             $instance = $this->app->make($name);


### PR DESCRIPTION
#1220