### PR TITLE
Compatibility fix for Laravel 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^5.5.9 || ^7.0",
         "dingo/blueprint": "0.2.*",
-        "doctrine/annotations": "1.2.*",
+        "doctrine/annotations": "1.2.* || 1.3.*",
         "illuminate/routing": "5.1.* || 5.2.* || 5.3.*",
         "illuminate/support": "5.1.* || 5.2.* || 5.3.*",
         "league/fractal": ">=0.12.0"


### PR DESCRIPTION
This should fix https://github.com/dingo/api/issues/1263 - there's a constraint conflict in doctrine/annotations between "1.2.*" (which dingo/api uses) and "1.3.*" (which comes with Laravel 5.3).

According to https://github.com/doctrine/annotations/blob/master/CHANGELOG.md#130 there should be no breaking changes, so it should be safe to use.

I'd prefer to use "~1.2" to avoid this issue in the future, but I'm not too familiar with dingo/api's internals to be able to say this is 100% correct. I'll leave that decision to you @jasonlewis 