### PR TITLE
Minor updates to support Laravel 5.4

### DIFF
--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -119,7 +119,7 @@ class Laravel implements Adapter
      */
     public function getRouteProperties($route, Request $request)
     {
-        return [$route->getUri(), $route->getMethods(), $route->getAction()];
+        return [$route->uri(), $route->methods, $route->getAction()];
     }
 
     /**


### PR DESCRIPTION
Hi,

I have just upgraded to Laravel 5.4 and noticed a couple of changes to the methods available on the Illuminate\Routing\Route class. This pull request uses the new method for uri() and the public property for methods.