### PR TITLE
Laravel 5.4 Illuminate/Routing/Route class changes.

### DIFF
--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -5,8 +5,8 @@ namespace Dingo\Api\Routing\Adapter;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
-use Illuminate\Routing\RouteCollection;
 use Dingo\Api\Contract\Routing\Adapter;
+use Illuminate\Routing\RouteCollection;
 use Dingo\Api\Exception\UnknownVersionException;
 
 class Laravel implements Adapter

--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -119,7 +119,7 @@ class Laravel implements Adapter
      */
     public function getRouteProperties($route, Request $request)
     {
-        return [$route->getUri(), $route->getMethods(), $route->getAction()];
+        return [$route->uri(), $route->methods(), $route->getAction()];
     }
 
     /**

--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -119,7 +119,11 @@ class Laravel implements Adapter
      */
     public function getRouteProperties($route, Request $request)
     {
-        return [$route->uri(), $route->methods(), $route->getAction()];
+        if (method_exists($route, 'uri') && method_exists($route, 'methods')) {
+            return [$route->uri(), $route->methods(), $route->getAction()];
+        }
+
+        return [$route->getUri(), $route->getMethods(), $route->getAction()];
     }
 
     /**


### PR DESCRIPTION
getUri() method was renamed to uri(), and getMethods() method was
renamed to methods().
See https://laravel.com/api/5.4/Illuminate/Routing/Route.html