### PR TITLE
Fix Http Response parsing laravel jsonp content

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -11,8 +11,8 @@ use Dingo\Api\Event\ResponseWasMorphed;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Response as IlluminateResponse;
 use Illuminate\Events\Dispatcher as EventDispatcher;
-use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Dingo\Api\Transformer\Factory as TransformerFactory;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
@@ -96,14 +96,14 @@ class Response extends IlluminateResponse
     public static function makeFromJson(JsonResponse $json)
     {
         $content = $json->getContent();
-        
+
         // If the contents of the JsonResponse does not starts with /**/ (typical laravel jsonp response)
         // we assume that it is a valid json response that can be decoded, or we just use the raw jsonp
         // contents for building the response
-        if(!starts_with($json->getContent(), '/**/')) {
+        if (! starts_with($json->getContent(), '/**/')) {
             $content = json_decode($json->getContent(), true);
         }
-        
+
         $new = static::create($content, $json->getStatusCode());
 
         $new->headers = $json->headers;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -95,7 +95,16 @@ class Response extends IlluminateResponse
      */
     public static function makeFromJson(JsonResponse $json)
     {
-        $new = static::create(json_decode($json->getContent(), true), $json->getStatusCode());
+        $content = $json->getContent();
+        
+        // If the contents of the JsonResponse does not starts with /**/ (typical laravel jsonp response)
+        // we assume that it is a valid json response that can be decoded, or we just use the raw jsonp
+        // contents for building the response
+        if(!starts_with($json->getContent(), '/**/')) {
+            $content = json_decode($json->getContent(), true);
+        }
+        
+        $new = static::create($content, $json->getStatusCode());
 
         $new->headers = $json->headers;
 


### PR DESCRIPTION
Hi,

**The problem** : Actually DingoApi empty all jsonp responses built with the default laravel response builder from a controller.

This works well :

```php
return response()->json([
    'foo' => 'bar',
]);
```

This return an empty response :
```php
return response()->json([
    'foo' => 'bar',
])->withCallback("test");
```

**The reason** : The `Dingo\Api\Http\Response` try to `json_decode()` the jsonp. This decode fails (because of the format of the jsonp) and return a empty json response.

**The fix** : Check if the contents contains a `/**/` at the beginning of the contents. Laravel make a `JsonResponse` for `json` and `jsonp` responses, so we cannot identify it with a class based detection. This simple check avoid a failing `json_decode`, and allows valid json to be parsed.