### PR TITLE
Check encode of your data

### DIFF
--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -2,8 +2,8 @@
 
 namespace Dingo\Api\Http\Response\Format;
 
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Str;
 
 class Json extends Format
 {
@@ -18,7 +18,7 @@ class Json extends Format
     {
         $key = Str::singular($model->getTable());
 
-        if (! $model::$snakeAttributes) {
+        if (!$model::$snakeAttributes) {
             $key = Str::camel($key);
         }
 
@@ -41,7 +41,7 @@ class Json extends Format
         $model = $collection->first();
         $key = Str::plural($model->getTable());
 
-        if (! $model::$snakeAttributes) {
+        if (!$model::$snakeAttributes) {
             $key = Str::camel($key);
         }
 
@@ -98,8 +98,8 @@ class Json extends Format
     protected function encode($content)
     {
         $encodedString = json_encode($content);
-        if($encodedString===false){
-            throw new \ErrorException('Error encoding data in JSON format: '.json_last_error());
+        if ($encodedString === false) {
+            throw new \ErrorException('Error encoding data in JSON format: ' . json_last_error());
         }
         return $encodedString;
     }

--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -101,6 +101,7 @@ class Json extends Format
         if ($encodedString === false){
             throw new \ErrorException('Error encoding data in JSON format: '.json_last_error());
         }
+
         return $encodedString;
     }
 }

--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -97,6 +97,10 @@ class Json extends Format
      */
     protected function encode($content)
     {
-        return json_encode($content);
+        $encodedString = json_encode($content);
+        if($encodedString===false){
+            throw new \ErrorException('Error encoding data in JSON format: '.json_last_error());
+        }
+        return $encodedString;
     }
 }

--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -98,7 +98,7 @@ class Json extends Format
     protected function encode($content)
     {
         $encodedString = json_encode($content);
-        if ($encodedString === false){
+        if ($encodedString === false) {
             throw new \ErrorException('Error encoding data in JSON format: '.json_last_error());
         }
 

--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -98,7 +98,7 @@ class Json extends Format
     protected function encode($content)
     {
         $encodedString = json_encode($content);
-        if($encodedString === false){
+        if ($encodedString === false){
             throw new \ErrorException('Error encoding data in JSON format: '.json_last_error());
         }
         return $encodedString;

--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -2,8 +2,8 @@
 
 namespace Dingo\Api\Http\Response\Format;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
+use Illuminate\Contracts\Support\Arrayable;
 
 class Json extends Format
 {
@@ -18,7 +18,7 @@ class Json extends Format
     {
         $key = Str::singular($model->getTable());
 
-        if (!$model::$snakeAttributes) {
+        if (! $model::$snakeAttributes) {
             $key = Str::camel($key);
         }
 
@@ -41,7 +41,7 @@ class Json extends Format
         $model = $collection->first();
         $key = Str::plural($model->getTable());
 
-        if (!$model::$snakeAttributes) {
+        if (! $model::$snakeAttributes) {
             $key = Str::camel($key);
         }
 
@@ -98,8 +98,8 @@ class Json extends Format
     protected function encode($content)
     {
         $encodedString = json_encode($content);
-        if ($encodedString === false) {
-            throw new \ErrorException('Error encoding data in JSON format: ' . json_last_error());
+        if($encodedString === false){
+            throw new \ErrorException('Error encoding data in JSON format: '.json_last_error());
         }
         return $encodedString;
     }


### PR DESCRIPTION
When a transform returns non utf8 string the response of our api is 200Ok with empty body. That is because `encode` method returns `false`.

This code will be very uses full in debugging such errors.  

Turning to PHP7 and method types would help also.

