### PR TITLE
Fix 'Illegal offset type' error for non-object argument passed to hasBinding

### DIFF
--- a/src/Transformer/Factory.php
+++ b/src/Transformer/Factory.php
@@ -176,7 +176,7 @@ class Factory
 
         $class = is_object($class) ? get_class($class) : $class;
 
-        return isset($this->bindings[$class]);
+        return is_scalar($class) && isset($this->bindings[$class]);
     }
 
     /**


### PR DESCRIPTION
In situations that the parameter passed to `hasBinding` of Transformer for example is an array (suppose paginate a set of arrays and then the first() of the collection is an array and it's illegal for offset of ::$bindings) and it causes a fatal error. This pull request fix it.