### PR TITLE
Allow integration with Lumen-Route-Binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 sudo: false
+dist: trusty
 
 env:
   global:

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -77,8 +77,20 @@ class LumenServiceProvider extends DingoServiceProvider
         parent::register();
 
         $this->app->singleton('api.router.adapter', function ($app) {
-            return new LumenAdapter($app, new StdRouteParser, new GcbDataGenerator, GroupCountBased::class);
+            return new LumenAdapter($app, new StdRouteParser, new GcbDataGenerator, $this->getDispatcherResolver());
         });
+    }
+
+    /**
+     * Get the dispatcher resolver callback.
+     *
+     * @return \Closure
+     */
+    protected function getDispatcherResolver()
+    {
+        return function ($routeCollector) {
+            return new GroupCountBased($routeCollector->getData());
+        };
     }
 
     /**

--- a/src/Routing/Adapter/Lumen.php
+++ b/src/Routing/Adapter/Lumen.php
@@ -7,8 +7,8 @@ use ReflectionClass;
 use FastRoute\Dispatcher;
 use FastRoute\RouteParser;
 use Illuminate\Support\Str;
-use Illuminate\Http\Request;
 use FastRoute\DataGenerator;
+use Illuminate\Http\Request;
 use FastRoute\RouteCollector;
 use Laravel\Lumen\Application;
 use Dingo\Api\Contract\Routing\Adapter;
@@ -38,11 +38,11 @@ class Lumen implements Adapter
     protected $generator;
 
     /**
-     * FastRoute dispatcher class name.
+     * FastRoute dispatcher resolver callback.
      *
-     * @var string
+     * @var callable
      */
-    protected $dispatcher;
+    protected $dispatcherResolver;
 
     /**
      * Array of registered routes.
@@ -64,16 +64,16 @@ class Lumen implements Adapter
      * @param \Laravel\Lumen\Application $app
      * @param \FastRoute\RouteParser     $parser
      * @param \FastRoute\DataGenerator   $generator
-     * @param string                     $dispatcher
+     * @param callable                   $dispatcherResolver
      *
      * @return void
      */
-    public function __construct(Application $app, RouteParser $parser, DataGenerator $generator, $dispatcher)
+    public function __construct(Application $app, RouteParser $parser, DataGenerator $generator, callable $dispatcherResolver)
     {
         $this->app = $app;
         $this->parser = $parser;
         $this->generator = $generator;
-        $this->dispatcher = $dispatcher;
+        $this->dispatcherResolver = $dispatcherResolver;
     }
 
     /**
@@ -92,11 +92,10 @@ class Lumen implements Adapter
 
         $this->removeMiddlewareFromApp();
 
-        $routes = $this->routes[$version];
+        $routeCollector = $this->routes[$version];
+        $dispatcher = call_user_func($this->dispatcherResolver, $routeCollector);
 
-        $this->app->setDispatcher(
-            new $this->dispatcher($routes->getData())
-        );
+        $this->app->setDispatcher($dispatcher);
 
         $this->normalizeRequestUri($request);
 

--- a/tests/Routing/Adapter/LumenTest.php
+++ b/tests/Routing/Adapter/LumenTest.php
@@ -25,7 +25,9 @@ class LumenTest extends BaseAdapterTest
             $request->setRouteResolver($app[Request::class]->getRouteResolver());
         });
 
-        return new Lumen($this->container, new StdRouteParser, new GcbDataGenerator, GcbDispatcher::class);
+        return new Lumen($this->container, new StdRouteParser, new GcbDataGenerator, function ($routes) {
+            return new GcbDispatcher($routes->getData());
+        });
     }
 
     public function getContainerInstance()


### PR DESCRIPTION
Set dispatcher for Lumen by resolver callback.

This will allow us to easily pass a custom dispatcher for Lumen by extending the service provider, needed to allow integration with [lumen-route-binding](https://github.com/mmghv/lumen-route-binding), A package to add support for `Route Model Binding` in Lumen.
