### PR TITLE
fix: Call the correct session setter in Laravel 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 sudo: false
+dist: trusty
 
 env:
   global:

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -37,7 +37,7 @@ class Request extends IlluminateRequest implements RequestInterface
         );
 
         if ($session = $old->getSession()) {
-            $new->setSession($old->getSession());
+            $new->setLaravelSession($old->getSession());
         }
 
         $new->setRouteResolver($old->getRouteResolver());


### PR DESCRIPTION
The http session is refactored in Laravel 5.4. The session handlers no longer implements Symfony's SessionInterface. 
Check links as below,
https://github.com/laravel/framework/pull/17064
https://laravel.com/docs/5.4/upgrade