### PR TITLE
Fix Laravel 5.5 compatibility with "getDomain"

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -621,6 +621,17 @@ class Route
     }
 
     /**
+     * Get the domain defined for the route.
+     * Use in Laravel 5.5+
+     *
+     * @return string|null
+     */
+    public function getDomain()
+    {
+        return Arr::get($this->action, 'domain');
+    }
+
+    /**
      * Get the original route.
      *
      * @return array|\Illuminate\Routing\Route

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -622,7 +622,7 @@ class Route
 
     /**
      * Get the domain defined for the route.
-     * Use in Laravel 5.5+
+     * Use in Laravel 5.5+.
      *
      * @return string|null
      */


### PR DESCRIPTION
Fix a bug with Laravel 5.5 (see https://github.com/dingo/api/issues/1413#issuecomment-318879644)

```php
PHP error:  Call to undefined method Dingo\Api\Routing\Route::getDomain() in /var/www/app.dev/vendor/laravel/framework/src/Illuminate/Routing/RouteUrlGenerator.php on line 114
```