### PR TITLE
Fixes HHVM Travis Tests break.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     - setup=basic
     - xdebug=true
 
+# HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
+dist: trusty
+
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
Fixes HHVM is no longer supported:

 - HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.


