### PR TITLE
L5.5: Add support for in-browser Mailable previews

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -3,6 +3,7 @@
 namespace Dingo\Api\Http;
 
 use ArrayObject;
+use Illuminate\Mail\Mailable;
 use UnexpectedValueException;
 use Illuminate\Http\JsonResponse;
 use Dingo\Api\Transformer\Binding;
@@ -134,6 +135,10 @@ class Response extends IlluminateResponse
         } elseif (is_array($this->content) || $this->content instanceof ArrayObject || $this->content instanceof Arrayable) {
             $this->content = $formatter->formatArray($this->content);
         } else {
+            if ($this->content instanceof Mailable) {
+                $this->content = $this->content->render();
+            }
+
             $this->headers->set('Content-Type', $defaultContentType);
         }
 


### PR DESCRIPTION
Since Laravel 5.5 Mailable templates [can be previewed in the browser](https://laravel.com/docs/5.5/mail#previewing-mailables-in-the-browser).

However, Dingo API currently throws an obscure error if you try and preview a Mailable:
```
sha1() expects parameter 1 to be string, object given {"exception":"[object] (ErrorException(code: 0): sha1() expects parameter 1 to be string, object given at /home/vagrant/Code/example/api/vendor/dingo/api/src/Routing/Router.php:566);
```

This is due to the Router attempting to format the Response `content` to json (or alternative format based on your API config):
https://github.com/dingo/api/blob/46cffad61942caa094dd876155e503b6819c5095/src/Routing/Router.php#L559

This fix simply sets the Response `content` to the rendered content of the Mailable instance.

I was unable to add any tests because Dingo API works on the back of the Lumen framework, which doesn't include the Mailable class.

This should obviously only be merged once Dingo API has support for Laravel 5.5.