### PR TITLE
Fix api:routes command for Laravel 5.5

### DIFF
--- a/src/Console/Command/Routes.php
+++ b/src/Console/Command/Routes.php
@@ -75,6 +75,18 @@ class Routes extends RouteListCommand
     }
 
     /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->routes = $this->router->getRoutes();
+
+        parent::handle();
+    }
+
+    /**
      * Compile the routes into a displayable format.
      *
      * @return array


### PR DESCRIPTION
For laravel 5.5 it is required that the command implements `handle` instead of `fire`. This PR fixes this but keeps the `fire` method (as not to break older versions where `handle` might not be called/used).