### PR TITLE
Laravel 5.5 package discovery support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,10 @@
         "restful"
     ],
     "license": "BSD-3-Clause",
-    "authors": [
-        {
-            "name": "Jason Lewis",
-            "email": "jason.lewis1991@gmail.com"
-        }
-    ],
+    "authors": [{
+        "name": "Jason Lewis",
+        "email": "jason.lewis1991@gmail.com"
+    }],
     "require": {
         "php": "^5.5.9 || ^7.0",
         "dingo/blueprint": "0.2.*",
@@ -57,6 +55,15 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Dingo\\Api\\Provider\\LaravelServiceProvider"
+            ],
+            "aliases": {
+                "API": "Dingo\\Api\\Facade\\API",
+                "Route": "Dingo\\Api\\Facade\\Route"
+            }
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
You may update installation guide in your wiki not update providers and aliases array manually.