### PR TITLE
Revert "Allow validation to pass through on Internal Requests"

### DIFF
--- a/src/Http/FormRequest.php
+++ b/src/Http/FormRequest.php
@@ -18,9 +18,7 @@ class FormRequest extends IlluminateFormRequest
      */
     protected function failedValidation(Validator $validator)
     {
-        if ($this->container['request'] instanceof InternalRequest) {
-            // Do nothing and pass thru to the parent
-        } elseif ($this->container['request'] instanceof Request) {
+        if ($this->container['request'] instanceof Request) {
             throw new ValidationHttpException($validator->errors());
         }
 


### PR DESCRIPTION
Reverts dingo/api#1367

There was 1 failure:
1) Dingo\Api\Tests\Http\Middleware\RateLimitTest::testRateLimitingFailsAndHeadersAreSetOnException
Failed asserting that 3600 is identical to 3599.
/home/travis/build/dingo/api/tests/Http/Middleware/RateLimitTest.php:134
