### PR TITLE
Fix "Canno't install Dingo API / Laravel 5.5.19" (#1479)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "league/fractal": "^0.17"
     },
     "require-dev": {
+        "phpdocumentor/reflection-docblock": "3.3.2",
         "friendsofphp/php-cs-fixer": "~2",
         "illuminate/auth": "^5.1",
         "illuminate/cache": "^5.1",


### PR DESCRIPTION
I try to fix the issue #1479 .
Add `"phpdocumentor/reflection-docblock": "3.3.2",` in composer.json