### PR TITLE
Revert "I think we can remove the method "through()" from here"

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -122,7 +122,7 @@ class Request
     {
         $this->app->instance('request', $request);
 
-        return (new Pipeline($this->app))->send($request)->then(function ($request) {
+        return (new Pipeline($this->app))->send($request)->through($this->middleware)->then(function ($request) {
             return $this->router->dispatch($request);
         });
     }


### PR DESCRIPTION
Reverts dingo/api#1494

This stops running any middlewares (application's global HTTP middleware stack) defined in the Kernel.php 