### PR TITLE
Remove the method removeMiddlewareFromApp() 

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -122,7 +122,10 @@ class Request
     {
         $this->app->instance('request', $request);
 
-        return (new Pipeline($this->app))->send($request)->then(function ($request) {
+        if (str_contains(get_class($this->app), 'Lumen')) {
+            $this->middleware = [];
+        }
+        return (new Pipeline($this->app))->send($request)->through($this->middleware)->then(function ($request) {
             return $this->router->dispatch($request);
         });
     }

--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -125,6 +125,7 @@ class Request
         if (str_contains(get_class($this->app), 'Lumen')) {
             $this->middleware = [];
         }
+
         return (new Pipeline($this->app))->send($request)->through($this->middleware)->then(function ($request) {
             return $this->router->dispatch($request);
         });

--- a/src/Routing/Adapter/Lumen.php
+++ b/src/Routing/Adapter/Lumen.php
@@ -3,7 +3,6 @@
 namespace Dingo\Api\Routing\Adapter;
 
 use ArrayIterator;
-use ReflectionClass;
 use FastRoute\Dispatcher;
 use FastRoute\RouteParser;
 use Illuminate\Support\Str;

--- a/src/Routing/Adapter/Lumen.php
+++ b/src/Routing/Adapter/Lumen.php
@@ -104,8 +104,6 @@ class Lumen implements Adapter
             throw new UnknownVersionException;
         }
 
-        $this->removeMiddlewareFromApp();
-
         $routeCollector = $this->mergeOldRoutes($version);
         $dispatcher = call_user_func($this->dispatcherResolver, $routeCollector);
 

--- a/src/Routing/Adapter/Lumen.php
+++ b/src/Routing/Adapter/Lumen.php
@@ -242,35 +242,6 @@ class Lumen implements Adapter
     }
 
     /**
-     * Remove the global application middleware as it's run from this packages
-     * Request middleware. Lumen runs middleware later in its life cycle
-     * which results in some middleware being executed twice.
-     *
-     * @return void
-     */
-    protected function removeMiddlewareFromApp()
-    {
-        if ($this->middlewareRemoved) {
-            return;
-        }
-
-        $this->middlewareRemoved = true;
-
-        $reflection = new ReflectionClass($this->app);
-        $property = $reflection->getProperty('middleware');
-        $property->setAccessible(true);
-        $oldMiddlewares = $property->getValue($this->app);
-        $newMiddlewares = [];
-        foreach ($oldMiddlewares as $middle) {
-            if ((new ReflectionClass($middle))->hasMethod('terminate') && $middle != 'Dingo\Api\Http\Middleware\Request') {
-                $newMiddlewares = array_merge($newMiddlewares, [$middle]);
-            }
-        }
-        $property->setValue($this->app, $newMiddlewares);
-        $property->setAccessible(false);
-    }
-
-    /**
      * Get all routes or only for a specific version.
      *
      * @param string $version


### PR DESCRIPTION
 Middleware will be executed on lumen twice ,In #1503,I have removed the middleware,so I think the method "removeMiddlewareFromApp()" can be removed too.