### PR TITLE
Change paginator to output json format. 

### DIFF
--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -155,7 +155,7 @@ class Factory
 
         $binding = $this->transformer->register($class, $transformer, $parameters, $after);
 
-        return new Response($paginator, 200, [], $binding);
+        return new Response($paginator->toJson(), 200, [], $binding);
     }
 
     /**


### PR DESCRIPTION
We use dingo/api to build api site , when use paginator function, the response output did not include previous page  url and next page url . so add toJson() to $paginator will fix this.