### PR TITLE
Fix FormRequests missing class error

### DIFF
--- a/src/Http/FormRequest.php
+++ b/src/Http/FormRequest.php
@@ -143,7 +143,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      *
      * @return void
-     *
      */
     protected function failedValidation(Validator $validator)
     {
@@ -158,6 +157,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Get the proper failed validation response for the request.
      *
      * @param  array  $errors
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function response(array $errors)
@@ -175,6 +175,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Format the errors from the given Validator instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
      * @return array
      */
     protected function formatErrors(Validator $validator)

--- a/src/Http/FormRequest.php
+++ b/src/Http/FormRequest.php
@@ -2,19 +2,146 @@
 
 namespace Dingo\Api\Http;
 
-use Illuminate\Contracts\Validation\Validator;
 use Dingo\Api\Exception\ValidationHttpException;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Laravel\Lumen\Http\Redirector;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidatesWhenResolvedTrait;
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Foundation\Http\FormRequest as IlluminateFormRequest;
 
-class FormRequest extends IlluminateFormRequest
+class FormRequest extends Request implements ValidatesWhenResolved
 {
+    use ValidatesWhenResolvedTrait;
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * The redirector instance.
+     *
+     * @var \Illuminate\Routing\Redirector
+     */
+    protected $redirector;
+
+    /**
+     * The URI to redirect to if validation fails.
+     *
+     * @var string
+     */
+    protected $redirect;
+
+    /**
+     * The route to redirect to if validation fails.
+     *
+     * @var string
+     */
+    protected $redirectRoute;
+
+    /**
+     * The controller action to redirect to if validation fails.
+     *
+     * @var string
+     */
+    protected $redirectAction;
+
+    /**
+     * The key to be used for the view error bag.
+     *
+     * @var string
+     */
+    protected $errorBag = 'default';
+
+    /**
+     * The input keys that should not be flashed on redirect.
+     *
+     * @var array
+     */
+    protected $dontFlash = [
+        'password',
+        'password_confirmation'
+    ];
+
+    /**
+     * Validate the request.
+     */
+    public function validate()
+    {
+        if ($this->authorize() === false) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $validator = app('validator')->make($this->all(), $this->rules(), $this->messages());
+
+        if ($validator->fails()) {
+            throw new ValidationHttpException($validator->errors());
+        }
+    }
+
+    /**
+     * Get the validator instance for the request.
+     *
+     * @return \Illuminate\Contracts\Validation\Validator
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
+    protected function getValidatorInstance()
+    {
+        $factory = $this->container->make(ValidationFactory::class);
+
+        if (method_exists($this, 'validator')) {
+            $validator = $this->container->call([$this, 'validator'], compact('factory'));
+        } else {
+            $validator = $this->createDefaultValidator($factory);
+        }
+
+        if (method_exists($this, 'withValidator')) {
+            $this->withValidator($validator);
+        }
+
+        return $validator;
+    }
+
+    /**
+     * Create the default validator instance.
+     *
+     * @param  \Illuminate\Contracts\Validation\Factory  $factory
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    protected function createDefaultValidator(ValidationFactory $factory)
+    {
+        return $factory->make(
+            $this->validationData(),
+            $this->container->call([$this, 'rules']),
+            $this->messages(),
+            $this->attributes()
+        );
+    }
+
+    /**
+     * Get data to be validated from the request.
+     *
+     * @return array
+     */
+    protected function validationData()
+    {
+        return $this->all();
+    }
+
     /**
      * Handle a failed validation attempt.
      *
-     * @param \Illuminate\Contracts\Validation\Validator $validator
-     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
+     *
      */
     protected function failedValidation(Validator $validator)
     {
@@ -26,9 +153,72 @@ class FormRequest extends IlluminateFormRequest
     }
 
     /**
+     * Get the proper failed validation response for the request.
+     *
+     * @param  array  $errors
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function response(array $errors)
+    {
+        if ($this->expectsJson()) {
+            return new JsonResponse($errors, 422);
+        }
+
+        return $this->redirector->to($this->getRedirectUrl())
+            ->withInput($this->except($this->dontFlash))
+            ->withErrors($errors, $this->errorBag);
+    }
+
+    /**
+     * Format the errors from the given Validator instance.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return array
+     */
+    protected function formatErrors(Validator $validator)
+    {
+        return $validator->getMessageBag()->toArray();
+    }
+
+    /**
+     * Get the URL to redirect to on a validation error.
+     *
+     * @return string
+     */
+    protected function getRedirectUrl()
+    {
+        $url = $this->redirector->getUrlGenerator();
+
+        if ($this->redirect) {
+            return $url->to($this->redirect);
+        } elseif ($this->redirectRoute) {
+            return $url->route($this->redirectRoute);
+        } elseif ($this->redirectAction) {
+            return $url->action($this->redirectAction);
+        }
+
+        return $url->previous();
+    }
+
+    /**
+     * Determine if the request passes the authorization check.
+     *
+     * @return bool
+     */
+    protected function passesAuthorization()
+    {
+        if (method_exists($this, 'authorize')) {
+            return $this->container->call([$this, 'authorize']);
+        }
+
+        return false;
+    }
+
+    /**
      * Handle a failed authorization attempt.
      *
      * @return void
+     *
      */
     protected function failedAuthorization()
     {
@@ -37,5 +227,51 @@ class FormRequest extends IlluminateFormRequest
         }
 
         parent::failedAuthorization();
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [];
+    }
+
+    /**
+     * Set the Redirector instance.
+     *
+     * @param Redirector $redirector
+     * @return $this
+     */
+    public function setRedirector(Redirector $redirector)
+    {
+        $this->redirector = $redirector;
+
+        return $this;
+    }
+
+    /**
+     * Set the container implementation.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return $this
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+
+        return $this;
     }
 }

--- a/src/Http/FormRequest.php
+++ b/src/Http/FormRequest.php
@@ -2,17 +2,17 @@
 
 namespace Dingo\Api\Http;
 
-use Dingo\Api\Exception\ValidationHttpException;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Laravel\Lumen\Http\Redirector;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Validator;
+use Dingo\Api\Exception\ValidationHttpException;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FormRequest extends Request implements ValidatesWhenResolved
 {
@@ -67,7 +67,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected $dontFlash = [
         'password',
-        'password_confirmation'
+        'password_confirmation',
     ];
 
     /**
@@ -114,6 +114,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Create the default validator instance.
      *
      * @param  \Illuminate\Contracts\Validation\Factory  $factory
+     *
      * @return \Illuminate\Contracts\Validation\Validator
      */
     protected function createDefaultValidator(ValidationFactory $factory)
@@ -140,6 +141,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Handle a failed validation attempt.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
      * @return void
      *
      */
@@ -218,7 +220,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Handle a failed authorization attempt.
      *
      * @return void
-     *
      */
     protected function failedAuthorization()
     {
@@ -253,6 +254,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Set the Redirector instance.
      *
      * @param Redirector $redirector
+     *
      * @return $this
      */
     public function setRedirector(Redirector $redirector)
@@ -266,6 +268,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Set the container implementation.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
+     *
      * @return $this
      */
     public function setContainer(Container $container)

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -9,6 +9,8 @@ use Laravel\Lumen\Http\Redirector;
 use Dingo\Api\Http\Middleware\Auth;
 use Dingo\Api\Http\Middleware\Request;
 use Dingo\Api\Http\Middleware\RateLimit;
+use FastRoute\Dispatcher\GroupCountBased;
+use Dingo\Api\Http\Middleware\PrepareController;
 use FastRoute\RouteParser\Std as StdRouteParser;
 use Illuminate\Http\Request as IlluminateRequest;
 use Dingo\Api\Routing\Adapter\Lumen as LumenAdapter;

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -21,9 +21,9 @@ class LumenServiceProvider extends DingoServiceProvider
     /**
      * Boot the service provider.
      *
-     * @return void
-     *
      * @throws \ReflectionException
+     *
+     * @return void
      */
     public function boot()
     {

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace Dingo\Api\Provider;
 
+use Dingo\Api\Http\FormRequest;
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
+use Laravel\Lumen\Application;
+use Laravel\Lumen\Http\Redirector;
 use ReflectionClass;
 use Dingo\Api\Http\Middleware\Auth;
 use Dingo\Api\Http\Middleware\Request;
@@ -19,6 +23,7 @@ class LumenServiceProvider extends DingoServiceProvider
      * Boot the service provider.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function boot()
     {
@@ -46,6 +51,16 @@ class LumenServiceProvider extends DingoServiceProvider
 
                 return $property->getValue($app);
             });
+        });
+
+        $this->app->afterResolving(ValidatesWhenResolved::class, function ($resolved) {
+            $resolved->validate();
+        });
+
+        $this->app->resolving(FormRequest::class, function (FormRequest $request, Application $app) {
+            $this->initializeRequest($request, $app['request']);
+
+            $request->setContainer($app)->setRedirector($app->make(Redirector::class));
         });
 
         $this->app->routeMiddleware([
@@ -130,5 +145,39 @@ class LumenServiceProvider extends DingoServiceProvider
         $middleware = $property->getValue($this->app);
 
         return $middleware;
+    }
+
+    /**
+     * Initialize the form request with data from the given request.
+     *
+     * @param FormRequest $form
+     * @param IlluminateRequest $current
+     * @return void
+     */
+    protected function initializeRequest(FormRequest $form, IlluminateRequest $current)
+    {
+        $files = $current->files->all();
+
+        $files = is_array($files) ? array_filter($files) : $files;
+
+        $form->initialize(
+            $current->query->all(),
+            $current->request->all(),
+            $current->attributes->all(),
+            $current->cookies->all(),
+            $files,
+            $current->server->all(),
+            $current->getContent()
+        );
+
+        $form->setJson($current->json());
+
+        if ($session = $current->getSession()) {
+            $form->setLaravelSession($session);
+        }
+
+        $form->setUserResolver($current->getUserResolver());
+
+        $form->setRouteResolver($current->getRouteResolver());
     }
 }

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -9,7 +9,6 @@ use Laravel\Lumen\Http\Redirector;
 use Dingo\Api\Http\Middleware\Auth;
 use Dingo\Api\Http\Middleware\Request;
 use Dingo\Api\Http\Middleware\RateLimit;
-
 use FastRoute\RouteParser\Std as StdRouteParser;
 use Illuminate\Http\Request as IlluminateRequest;
 use Dingo\Api\Routing\Adapter\Lumen as LumenAdapter;

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -2,19 +2,18 @@
 
 namespace Dingo\Api\Provider;
 
-use Dingo\Api\Http\FormRequest;
-use Illuminate\Contracts\Validation\ValidatesWhenResolved;
-use Laravel\Lumen\Application;
-use Laravel\Lumen\Http\Redirector;
 use ReflectionClass;
+use Laravel\Lumen\Application;
+use Dingo\Api\Http\FormRequest;
+use Laravel\Lumen\Http\Redirector;
 use Dingo\Api\Http\Middleware\Auth;
 use Dingo\Api\Http\Middleware\Request;
 use Dingo\Api\Http\Middleware\RateLimit;
-use FastRoute\Dispatcher\GroupCountBased;
-use Dingo\Api\Http\Middleware\PrepareController;
+
 use FastRoute\RouteParser\Std as StdRouteParser;
 use Illuminate\Http\Request as IlluminateRequest;
 use Dingo\Api\Routing\Adapter\Lumen as LumenAdapter;
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use FastRoute\DataGenerator\GroupCountBased as GcbDataGenerator;
 
 class LumenServiceProvider extends DingoServiceProvider
@@ -23,6 +22,7 @@ class LumenServiceProvider extends DingoServiceProvider
      * Boot the service provider.
      *
      * @return void
+     *
      * @throws \ReflectionException
      */
     public function boot()
@@ -152,6 +152,7 @@ class LumenServiceProvider extends DingoServiceProvider
      *
      * @param FormRequest $form
      * @param IlluminateRequest $current
+     *
      * @return void
      */
     protected function initializeRequest(FormRequest $form, IlluminateRequest $current)


### PR DESCRIPTION
Lumen does not contain the Illuminate\Foundation\Http\FormRequest class.

I merged the original file and the Laravel FormRequest class into the Dingo FormRequest class.

I added the ValidatesWhenResolvedTrait resolving to the LumenServiceProvider too.