### PR TITLE
Add getMiddleware function to Route class

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -533,4 +533,14 @@ class Route extends \Illuminate\Routing\Route
     {
         return in_array('https', $this->action, true);
     }
+    
+     /**
+     * Return the middlewares for this route.
+     *
+     * @return array
+     */
+    public function getMiddleware()
+    {
+        return $this->middleware;
+    }
 }

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -534,7 +534,7 @@ class Route extends \Illuminate\Routing\Route
         return in_array('https', $this->action, true);
     }
     
-     /**
+    /**
      * Return the middlewares for this route.
      *
      * @return array

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -533,7 +533,7 @@ class Route extends \Illuminate\Routing\Route
     {
         return in_array('https', $this->action, true);
     }
-    
+
     /**
      * Return the middlewares for this route.
      *


### PR DESCRIPTION
The getMiddleware function is missing and reported here: https://github.com/flipboxstudio/lumen-generator/issues/25
Also I think you have to be able to query the middlewares.

If the function is not necessary and you can query the middlewares with another method, please write it in the comments.