### PR TITLE
Laravel compatibility with RouteCollection::add()

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -34,13 +34,15 @@ class RouteCollection implements Countable, IteratorAggregate
      *
      * @param \Dingo\Api\Routing\Route $route
      *
-     * @return void
+     * @return \Dingo\Api\Routing\Route
      */
     public function add(Route $route)
     {
         $this->routes[] = $route;
 
         $this->addLookups($route);
+
+        return $route;
     }
 
     /**


### PR DESCRIPTION
Return Route from RouteCollection::add() for upstream compatibility with Laravel Router 
#1552 