### PR TITLE
Support for custom data includes in transformer

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -197,6 +197,11 @@ class Fractal implements Adapter
         foreach ($includes as $key => $value) {
             $eagerLoads[] = is_string($key) ? $key : $value;
         }
+		
+		if (property_exists($transformer, 'lazyLoadedIncludes')) {
+            $eagerLoads = array_diff($eagerLoads, $transformer->lazyLoadedIncludes);
+        }
+        
 
         return $eagerLoads;
     }


### PR DESCRIPTION
Quick fix for #1133 and related issues. 

The attribute `lazyLoadedIncludes` must be declared **public** in the transformer to make it work. Otherwise, it would have been necessary to change Fractal library to add a getter.

All the includes name listed in this array will not be loaded using eager loading. It is then possible to include custom data not linked to any relationship or model.