### PR TITLE
Add ability to use different Event Dispatchers

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -12,8 +12,8 @@ use Dingo\Api\Event\RequestWasMatched;
 use Dingo\Api\Http\Request as HttpRequest;
 use Illuminate\Contracts\Container\Container;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
-use Illuminate\Events\Dispatcher as EventDispatcher;
 use Dingo\Api\Contract\Http\Request as RequestContract;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler as LaravelExceptionHandler;
 
 class Request
@@ -49,7 +49,7 @@ class Request
     /**
      * Event dispatcher instance.
      *
-     * @var \Illuminate\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $events;
 
@@ -67,7 +67,7 @@ class Request
      * @param \Dingo\Api\Contract\Debug\ExceptionHandler   $exception
      * @param \Dingo\Api\Routing\Router                    $router
      * @param \Dingo\Api\Http\RequestValidator             $validator
-     * @param \Illuminate\Events\Dispatcher                $events
+     * @param \Illuminate\Contracts\Events\Dispatcher      $events
      *
      * @return void
      */
@@ -98,7 +98,7 @@ class Request
 
                 $request = $this->app->make(RequestContract::class)->createFromIlluminate($request);
 
-                $this->events->fire(new RequestWasMatched($request, $this->app));
+                $this->events->dispatch(new RequestWasMatched($request, $this->app));
 
                 return $this->sendRequestThroughRouter($request);
             }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -10,9 +10,9 @@ use Dingo\Api\Event\ResponseIsMorphing;
 use Dingo\Api\Event\ResponseWasMorphed;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Response as IlluminateResponse;
-use Illuminate\Events\Dispatcher as EventDispatcher;
 use Dingo\Api\Transformer\Factory as TransformerFactory;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
@@ -56,7 +56,7 @@ class Response extends IlluminateResponse
     /**
      * Event dispatcher instance.
      *
-     * @var \Illuminate\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected static $events;
 
@@ -169,7 +169,7 @@ class Response extends IlluminateResponse
             return;
         }
 
-        static::$events->fire(new ResponseWasMorphed($this, $this->content));
+        static::$events->dispatch(new ResponseWasMorphed($this, $this->content));
     }
 
     /**
@@ -183,7 +183,7 @@ class Response extends IlluminateResponse
             return;
         }
 
-        static::$events->fire(new ResponseIsMorphing($this, $this->content));
+        static::$events->dispatch(new ResponseIsMorphing($this, $this->content));
     }
 
     /**
@@ -207,7 +207,7 @@ class Response extends IlluminateResponse
     /**
      * Set the event dispatcher instance.
      *
-     * @param \Illuminate\Events\Dispatcher $events
+     * @param \Illuminate\Contracts\Events\Dispatcher $events
      *
      * @return void
      */


### PR DESCRIPTION
This PR adds to this package the ability to use different Event Dispatchers.

See https://github.com/fntneves/laravel-transactional-events/issues/16

Basically, I only replaced the use statement of the concrete `Event Dispatcher` class with its contract.