### PR TITLE
Fixed an issue with no content

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -556,7 +556,7 @@ class Router
 
         if ($response->isSuccessful() && $this->requestIsConditional()) {
             if (! $response->headers->has('ETag')) {
-                $response->setEtag(sha1($response->getContent()));
+                $response->setEtag(sha1($response->getContent() ?: ''));
             }
 
             $response->isNotModified($request);


### PR DESCRIPTION
Fixed "sha1() expects parameter 1 to be string, null given" when returning empty content