### PR TITLE
Instantiate new controller only if not resolved already

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -283,6 +283,8 @@ class Route extends \Illuminate\Routing\Route
         if (!$this->container->resolved($this->controllerClass)) {
             $this->container->instance($this->controllerClass,
                 $this->controller = $this->container->make($this->controllerClass));
+        } else {
+            $this->controller = $this->container->make($this->controllerClass);
         }
 
         return $this->controller;

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -280,8 +280,10 @@ class Route extends \Illuminate\Routing\Route
     {
         list($this->controllerClass, $this->controllerMethod) = explode('@', $this->action['uses']);
 
-        $this->container->instance($this->controllerClass,
-            $this->controller = $this->container->make($this->controllerClass));
+        if (!$this->container->resolved($this->controllerClass)) {
+            $this->container->instance($this->controllerClass,
+                $this->controller = $this->container->make($this->controllerClass));
+        }
 
         return $this->controller;
     }


### PR DESCRIPTION
This deals with issue https://github.com/dingo/api/issues/1608

I am not sure as to whether something has changed in Laravel which led to this problem, or if it's always been the case.

This change passed a large number of unit tests I have set up for projects using dingo, so I don't see any problem with this change, but looking for other people's feedback on whether they can sense any issues - especially on older laravel vesions.