### PR TITLE
Feature/implement param pattern matching

### DIFF
--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -47,6 +47,13 @@ class Laravel implements Adapter
     protected $oldRoutes;
 
     /**
+     * The globally available parameter patterns.
+     *
+     * @var array
+     */
+    protected $patterns = [];
+
+    /**
      * Create a new laravel routing adapter instance.
      *
      * @param \Illuminate\Routing\Router $router
@@ -244,5 +251,15 @@ class Laravel implements Adapter
     public function getRouter()
     {
         return $this->router;
+    }
+
+    /**
+     * Get the global "where" patterns.
+     *
+     * @return array
+     */
+    public function getPatterns()
+    {
+        return $this->patterns;
     }
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -14,6 +14,7 @@ use Dingo\Api\Http\InternalRequest;
 use Illuminate\Container\Container;
 use Dingo\Api\Contract\Routing\Adapter;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
+use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Http\Response as IlluminateResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
@@ -624,12 +625,14 @@ class Router
         }
 
         // We need to recompile the route, adding the where clause (for pattern restrictions) and check again
-        $route->compiled = false;
-        $this->addWhereClausesToRoute($route);
+        if (is_object($route) && $route instanceof IlluminateRoute) {
+            $route->compiled = false;
+            $this->addWhereClausesToRoute($route);
 
-        // If the matching fails, it would be due to a parameter format validation check fail
-        if (! $route->matches($this->container['request'])) {
-            throw new NotFoundHttpException();
+            // If the matching fails, it would be due to a parameter format validation check fail
+            if (! $route->matches($this->container['request'])) {
+                throw new NotFoundHttpException('Not Found!');
+            }
         }
 
         return $this->currentRoute = $this->createRoute($route);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -15,8 +15,8 @@ use Illuminate\Container\Container;
 use Dingo\Api\Contract\Routing\Adapter;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
 use Illuminate\Http\Response as IlluminateResponse;
-use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
 class Router
 {
@@ -859,6 +859,7 @@ class Router
      * Add the necessary where clauses to the route based on its initial registration.
      *
      * @param  \Illuminate\Routing\Route  $route
+     *
      * @return \Illuminate\Routing\Route
      */
     protected function addWhereClausesToRoute($route)

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -43,6 +43,8 @@ class DispatcherTest extends TestCase
         $this->auth = new Auth($this->router, $this->container, []);
         $this->dispatcher = new Dispatcher($this->container, new Filesystem, $this->router, $this->auth);
 
+        app()->instance(\Illuminate\Routing\Router::class, $this->adapter, true);
+
         $this->dispatcher->setSubtype('api');
         $this->dispatcher->setStandardsTree('vnd');
         $this->dispatcher->setDefaultVersion('v1');

--- a/tests/Routing/Adapter/BaseAdapterTest.php
+++ b/tests/Routing/Adapter/BaseAdapterTest.php
@@ -29,6 +29,7 @@ abstract class BaseAdapterTest extends TestCase
         $this->adapter = $this->getAdapterInstance();
         $this->exception = m::mock(\Dingo\Api\Exception\Handler::class);
         $this->router = new Router($this->adapter, $this->exception, $this->container, null, null);
+        app()->instance(\Illuminate\Routing\Router::class, $this->adapter, true);
 
         Http\Response::setFormatters(['json' => new Http\Response\Format\Json]);
     }

--- a/tests/Stubs/RoutingAdapterStub.php
+++ b/tests/Stubs/RoutingAdapterStub.php
@@ -111,6 +111,11 @@ class RoutingAdapterStub implements Adapter
         $this->patterns[$key] = $pattern;
     }
 
+    public function getPatterns()
+    {
+        return $this->patterns;
+    }
+
     protected function createRouteCollections(array $versions)
     {
         foreach ($versions as $version) {


### PR DESCRIPTION
For issue #1232

I spent a bit of time today looking at this, and it seems like there are very big deviations between Laravel's and Dingo's routing workflow. Whether this is by design or not... I really don't know. Anyway, I implemented this in a fairly simple way after some digging and digging, and it does seem to work for me, and passed a lot of unit tests in some large projects.

At the same time, the functionality is not 100% compatible with Laravel's Router - which checks each route individually, including this param pattern matching (until it finds the matching route), whereas this implementation does the same without param pattern matching, and then does that validation for the one found route at the end.

This could lead to inconsistent results if there are very ambiguous and routes defines (which is rather sloppy in any case).

Keen to have other people give this a try and give me feedback before I merge.