### PR TITLE
Add new methods to satisfy Application contract for Laravel 5.8

### DIFF
--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -82,13 +82,14 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
      * Determine if the exception should be reported.
      *
      * @param  \Exception  $e
+     *
      * @return bool
      */
     public function shouldReport(Exception $e)
     {
         return true;
     }
-    
+
     /**
      * Render an exception into an HTTP response.
      *

--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -79,6 +79,17 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
     }
 
     /**
+     * Determine if the exception should be reported.
+     *
+     * @param  \Exception  $e
+     * @return bool
+     */
+    public function shouldReport(Exception $e)
+    {
+        return true;
+    }
+    
+    /**
      * Render an exception into an HTTP response.
      *
      * @param \Dingo\Api\Http\Request $request

--- a/tests/ChecksLaravelVersionTrait.php
+++ b/tests/ChecksLaravelVersionTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Dingo\Api\Tests;
+
+use Dingo\Api\Tests\Stubs\ApplicationStub;
+use Dingo\Api\Tests\Stubs\Application58Stub;
+
+trait ChecksLaravelVersionTrait
+{
+
+  public $installed_file_path = __DIR__ . '/../vendor/composer/installed.json';
+  public $current_release = '5.8';
+
+  function getFrameworkVersion()
+  {
+    $contents = file_get_contents($this->installed_file_path);
+    $parsed_data = json_decode($contents, true);
+    $just_laravel = array_filter($parsed_data, function ($val) {
+      if ("laravel/framework" === $val['name'] || "laravel/lumen-framework" === $val['name']) {
+        return true;
+      }
+    });
+    $laravelVersion = array_map(function($val) {
+      return $val['version'];
+    }, array_values($just_laravel))[0];
+    return $laravelVersion;
+  }
+
+  function getApplicationStub()
+  {
+    $version = $this->getFrameworkVersion();
+    if ('dev-master' === $version) {
+      $version = $this->current_release;
+    }
+    $compared_versions = version_compare('5.8', $version);
+    if ( $compared_versions === -1 || $compared_versions === 0 ) {
+      return new Application58Stub;
+    }
+    return new ApplicationStub;
+  }
+}

--- a/tests/ChecksLaravelVersionTrait.php
+++ b/tests/ChecksLaravelVersionTrait.php
@@ -7,8 +7,7 @@ use Dingo\Api\Tests\Stubs\Application58Stub;
 
 trait ChecksLaravelVersionTrait
 {
-
-    public $installed_file_path = __DIR__ . '/../vendor/composer/installed.json';
+    public $installed_file_path = __DIR__.'/../vendor/composer/installed.json';
     public $current_release = '5.8';
 
     private function getFrameworkVersion()
@@ -16,13 +15,14 @@ trait ChecksLaravelVersionTrait
         $contents = file_get_contents($this->installed_file_path);
         $parsed_data = json_decode($contents, true);
         $just_laravel = array_filter($parsed_data, function ($val) {
-            if ("laravel/framework" === $val['name'] || "laravel/lumen-framework" === $val['name']) {
+            if ('laravel/framework' === $val['name'] || 'laravel/lumen-framework' === $val['name']) {
                 return true;
             }
         });
         $laravelVersion = array_map(function ($val) {
             return $val['version'];
         }, array_values($just_laravel))[0];
+
         return $laravelVersion;
     }
 
@@ -33,9 +33,11 @@ trait ChecksLaravelVersionTrait
             $version = $this->current_release;
         }
         $compared_versions = version_compare('5.8', $version);
+        // If comparison is Less Than, or Equal To, provide the 5.8 stub.
         if ($compared_versions === -1 || $compared_versions === 0) {
             return new Application58Stub;
         }
+
         return new ApplicationStub;
     }
 }

--- a/tests/ChecksLaravelVersionTrait.php
+++ b/tests/ChecksLaravelVersionTrait.php
@@ -8,34 +8,34 @@ use Dingo\Api\Tests\Stubs\Application58Stub;
 trait ChecksLaravelVersionTrait
 {
 
-  public $installed_file_path = __DIR__ . '/../vendor/composer/installed.json';
-  public $current_release = '5.8';
+    public $installed_file_path = __DIR__ . '/../vendor/composer/installed.json';
+    public $current_release = '5.8';
 
-  function getFrameworkVersion()
-  {
-    $contents = file_get_contents($this->installed_file_path);
-    $parsed_data = json_decode($contents, true);
-    $just_laravel = array_filter($parsed_data, function ($val) {
-      if ("laravel/framework" === $val['name'] || "laravel/lumen-framework" === $val['name']) {
-        return true;
-      }
-    });
-    $laravelVersion = array_map(function($val) {
-      return $val['version'];
-    }, array_values($just_laravel))[0];
-    return $laravelVersion;
-  }
+    private function getFrameworkVersion()
+    {
+        $contents = file_get_contents($this->installed_file_path);
+        $parsed_data = json_decode($contents, true);
+        $just_laravel = array_filter($parsed_data, function ($val) {
+            if ("laravel/framework" === $val['name'] || "laravel/lumen-framework" === $val['name']) {
+                return true;
+            }
+        });
+        $laravelVersion = array_map(function ($val) {
+            return $val['version'];
+        }, array_values($just_laravel))[0];
+        return $laravelVersion;
+    }
 
-  function getApplicationStub()
-  {
-    $version = $this->getFrameworkVersion();
-    if ('dev-master' === $version) {
-      $version = $this->current_release;
+    private function getApplicationStub()
+    {
+        $version = $this->getFrameworkVersion();
+        if ('dev-master' === $version) {
+            $version = $this->current_release;
+        }
+        $compared_versions = version_compare('5.8', $version);
+        if ($compared_versions === -1 || $compared_versions === 0) {
+            return new Application58Stub;
+        }
+        return new ApplicationStub;
     }
-    $compared_versions = version_compare('5.8', $version);
-    if ( $compared_versions === -1 || $compared_versions === 0 ) {
-      return new Application58Stub;
-    }
-    return new ApplicationStub;
-  }
 }

--- a/tests/Http/Middleware/RequestTest.php
+++ b/tests/Http/Middleware/RequestTest.php
@@ -12,7 +12,7 @@ use Dingo\Api\Http\RequestValidator;
 use Dingo\Api\Http\Validation\Accept;
 use Dingo\Api\Http\Validation\Domain;
 use Dingo\Api\Http\Validation\Prefix;
-use Dingo\Api\Tests\Stubs\ApplicationStub;
+use Dingo\Api\Tests\ChecksLaravelVersionTrait;
 use Dingo\Api\Http\Parser\Accept as AcceptParser;
 use Illuminate\Http\Request as IlluminateRequest;
 use Illuminate\Events\Dispatcher as EventDispatcher;
@@ -28,9 +28,11 @@ class RequestTest extends TestCase
     protected $events;
     protected $middleware;
 
+    use ChecksLaravelVersionTrait;
+
     public function setUp()
     {
-        $this->app = new ApplicationStub;
+        $this->app = $this->getApplicationStub();
         $this->router = m::mock(Router::class);
         $this->validator = new RequestValidator($this->app);
         $this->handler = m::mock(Handler::class);

--- a/tests/Stubs/Application58Stub.php
+++ b/tests/Stubs/Application58Stub.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Dingo\Api\Tests\Stubs;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+
+class Application58Stub extends Container implements Application
+{
+    public function version()
+    {
+        return 'v1';
+    }
+
+    public function basePath()
+    {
+        //
+    }
+
+    public function bootstrapPath($path = '')
+    {
+        //
+    }
+
+    public function configPath($path = '')
+    {
+        //
+    }
+
+    public function databasePath($path = '')
+    {
+        //
+    }
+
+    public function environmentPath()
+    {
+        //
+    }
+
+    public function resourcePath($path = '')
+    {
+        //
+    }
+
+    public function storagePath()
+    {
+        //
+    }
+
+    public function environment(...$environments)
+    {
+        return 'testing';
+    }
+
+    public function runningInConsole()
+    {
+        //
+    }
+
+    public function runningUnitTests()
+    {
+      // TODO: Implement runningUnitTests() method.
+    }
+
+    public function isDownForMaintenance()
+    {
+        return false;
+    }
+
+    public function registerConfiguredProviders()
+    {
+        //
+    }
+
+    public function register($provider, $options = [], $force = false)
+    {
+        //
+    }
+
+    public function registerDeferredProvider($provider, $service = null)
+    {
+        //
+    }
+
+    public function resolveProvider($provider)
+    {
+      //
+    }
+
+    public function boot()
+    {
+        //
+    }
+
+    public function booting($callback)
+    {
+        //
+    }
+
+    public function booted($callback)
+    {
+        //
+    }
+
+    public function bootstrapWith(array $bootstrappers)
+    {
+      //
+    }
+
+    public function configurationIsCached()
+    {
+      //
+    }
+
+    public function detectEnvironment(\Closure $callback)
+    {
+      //
+    }
+
+    public function environmentFile()
+    {
+      //
+    }
+
+    public function environmentFilePath()
+    {
+      //
+    }
+
+    public function getCachedConfigPath()
+    {
+      //
+    }
+
+    public function getCachedServicesPath()
+    {
+        //
+    }
+
+    public function getCachedPackagesPath()
+    {
+        //
+    }
+
+    public function getCachedRoutesPath()
+    {
+      //
+    }
+
+    public function getLocale()
+    {
+      //
+    }
+
+    public function getNamespace()
+    {
+      //
+    }
+
+    public function getProviders($provider)
+    {
+      //
+    }
+
+    public function hasBeenBootstrapped()
+    {
+      //
+    }
+
+    public function loadDeferredProviders()
+    {
+      //
+    }
+
+    public function loadEnvironmentFrom($file)
+    {
+      //
+    }
+
+    public function routesAreCached()
+    {
+      //
+    }
+
+    public function setLocale($locale)
+    {
+      //
+    }
+
+    public function shouldSkipMiddleware()
+    {
+      //
+    }
+
+    public function terminate()
+    {
+      //
+    }
+
+}

--- a/tests/Stubs/Application58Stub.php
+++ b/tests/Stubs/Application58Stub.php
@@ -59,7 +59,7 @@ class Application58Stub extends Container implements Application
 
     public function runningUnitTests()
     {
-      // TODO: Implement runningUnitTests() method.
+        // TODO: Implement runningUnitTests() method.
     }
 
     public function isDownForMaintenance()
@@ -84,7 +84,7 @@ class Application58Stub extends Container implements Application
 
     public function resolveProvider($provider)
     {
-      //
+        //
     }
 
     public function boot()
@@ -104,32 +104,32 @@ class Application58Stub extends Container implements Application
 
     public function bootstrapWith(array $bootstrappers)
     {
-      //
+        //
     }
 
     public function configurationIsCached()
     {
-      //
+        //
     }
 
     public function detectEnvironment(\Closure $callback)
     {
-      //
+        //
     }
 
     public function environmentFile()
     {
-      //
+        //
     }
 
     public function environmentFilePath()
     {
-      //
+        //
     }
 
     public function getCachedConfigPath()
     {
-      //
+        //
     }
 
     public function getCachedServicesPath()
@@ -144,57 +144,56 @@ class Application58Stub extends Container implements Application
 
     public function getCachedRoutesPath()
     {
-      //
+        //
     }
 
     public function getLocale()
     {
-      //
+        //
     }
 
     public function getNamespace()
     {
-      //
+        //
     }
 
     public function getProviders($provider)
     {
-      //
+        //
     }
 
     public function hasBeenBootstrapped()
     {
-      //
+        //
     }
 
     public function loadDeferredProviders()
     {
-      //
+        //
     }
 
     public function loadEnvironmentFrom($file)
     {
-      //
+        //
     }
 
     public function routesAreCached()
     {
-      //
+        //
     }
 
     public function setLocale($locale)
     {
-      //
+        //
     }
 
     public function shouldSkipMiddleware()
     {
-      //
+        //
     }
 
     public function terminate()
     {
-      //
+        //
     }
-
 }


### PR DESCRIPTION
## PR Not Final
Until Lumen publishes a tag for 5.8 the testing framework used for this package is broken. So the main option is to wait until that happens, with an alternaitive of simply modifying the dependency for lumen-framework to not use `dev-master`.

## Intent of PR

This PR adds all the new methods for Laravel 5.8 as required by the updated contract.

Fixes #1624

### Notes

This change also includes some necessary modifications to how testing works, so as to allow the tests to support Laravel 5.5-5.7 and 5.8. The package itself seems unaffected, just the tests were having issues.