### PR TITLE
Adds a URL generator function "route" to API facade

### DIFF
--- a/src/Facade/API.php
+++ b/src/Facade/API.php
@@ -93,10 +93,11 @@ class API extends Facade
     }
 
     /**
-     * Get the API route of the given name, and optionally specify the API version
+     * Get the API route of the given name, and optionally specify the API version.
      *
      * @param string $routeName
      * @param string $apiVersion
+     * 
      * @return string
      */
     public static function route($routeName, $apiVersion = 'v1')

--- a/src/Facade/API.php
+++ b/src/Facade/API.php
@@ -91,4 +91,16 @@ class API extends Facade
     {
         return static::$app['api.router'];
     }
+
+    /**
+     * Get the API route of the given name, and optionally specify the API version
+     *
+     * @param string $routeName
+     * @param string $apiVersion
+     * @return string
+     */
+    public static function route($routeName, $apiVersion = 'v1')
+    {
+        return static::$app['api.url']->version($apiVersion)->route($routeName);
+    }
 }

--- a/src/Facade/API.php
+++ b/src/Facade/API.php
@@ -97,7 +97,7 @@ class API extends Facade
      *
      * @param string $routeName
      * @param string $apiVersion
-     * 
+     *
      * @return string
      */
     public static function route($routeName, $apiVersion = 'v1')


### PR DESCRIPTION
Implement suggestion https://github.com/dingo/api/issues/1606

Could potentially add a global helper, but I think it's probably not necessary / goes against Laravel itself retiring some global namespace helpers.