### PR TITLE
Improving Response Factory Doc

### DIFF
--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -87,7 +87,7 @@ class Factory
      * Bind a collection to a transformer and start building a response.
      *
      * @param \Illuminate\Support\Collection $collection
-     * @param object                         $transformer
+     * @param string|callable|object         $transformer
      * @param array|\Closure                 $parameters
      * @param \Closure|null                  $after
      *
@@ -114,10 +114,10 @@ class Factory
     /**
      * Bind an item to a transformer and start building a response.
      *
-     * @param object   $item
-     * @param object   $transformer
-     * @param array    $parameters
-     * @param \Closure $after
+     * @param object                 $item
+     * @param string|callable|object $transformer
+     * @param array                  $parameters
+     * @param \Closure               $after
      *
      * @return \Dingo\Api\Http\Response
      */
@@ -139,7 +139,7 @@ class Factory
      * Bind a paginator to a transformer and start building a response.
      *
      * @param \Illuminate\Contracts\Pagination\Paginator $paginator
-     * @param object                                     $transformer
+     * @param string|callable|object                     $transformer
      * @param array                                      $parameters
      * @param \Closure                                   $after
      *


### PR DESCRIPTION
`$tranformer` accepts `string|callable|object` instead only of `object`