### PR TITLE
Validate FormRequest when resolved - add to Laravel service provider

### DIFF
--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Routing\ControllerDispatcher;
 use Dingo\Api\Http\Middleware\PrepareController;
 use Illuminate\Http\Request as IlluminateRequest;
 use Dingo\Api\Routing\Adapter\Laravel as LaravelAdapter;
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 
 class LaravelServiceProvider extends DingoServiceProvider
 {
@@ -41,6 +42,11 @@ class LaravelServiceProvider extends DingoServiceProvider
             $this->replaceRouteDispatcher();
 
             $this->updateRouterBindings();
+        });
+
+        // Validate FormRequest after resolving
+        $this->app->afterResolving(ValidatesWhenResolved::class, function ($resolved) {
+            $resolved->validateResolved();
         });
 
         $this->app->resolving(FormRequest::class, function (FormRequest $request, Application $app) {

--- a/src/Provider/LumenServiceProvider.php
+++ b/src/Provider/LumenServiceProvider.php
@@ -54,6 +54,7 @@ class LumenServiceProvider extends DingoServiceProvider
             });
         });
 
+        // Validate FormRequest after resolving
         $this->app->afterResolving(ValidatesWhenResolved::class, function ($resolved) {
             $resolved->validateResolved();
         });


### PR DESCRIPTION
Original credit goes to @sudkumar and his PR here https://github.com/dingo/api/pull/1654

I just ported the same functionality to the Laravel service provider.

After doing some testing, previously (as in previous to this PR), FormRequests were not being validated at the controller level upon resolution, and now they will be (which is the default and expected Laravel functionality).