### PR TITLE
Fix escaping multibyte Unicode characters.

### DIFF
--- a/src/Http/Response/Format/Json.php
+++ b/src/Http/Response/Format/Json.php
@@ -112,6 +112,7 @@ class Json extends Format
 
         if ($this->isJsonPrettyPrintEnabled()) {
             $jsonEncodeOptions[] = JSON_PRETTY_PRINT;
+            $jsonEncodeOptions[] = JSON_UNESCAPED_UNICODE;
         }
 
         $encodedString = $this->performJsonEncoding($content, $jsonEncodeOptions);

--- a/src/Http/Response/Format/JsonOptionalFormatting.php
+++ b/src/Http/Response/Format/JsonOptionalFormatting.php
@@ -43,6 +43,7 @@ trait JsonOptionalFormatting
      */
     protected $jsonEncodeOptionsWhitelist = [
         JSON_PRETTY_PRINT,
+        JSON_UNESCAPED_UNICODE,
     ];
 
     /**


### PR DESCRIPTION
Encode multibyte Unicode characters literally (default is to escape as \uXXXX).
e.g. Chinese, Japanese.

![Screen Shot 2019-08-22 at 8 35 37 PM](https://user-images.githubusercontent.com/1852808/63516556-b900b480-c51f-11e9-96ec-d9a0a68ec70d.png)

![Screen Shot 2019-08-22 at 8 34 33 PM](https://user-images.githubusercontent.com/1852808/63516557-baca7800-c51f-11e9-8480-f83e53345b31.png)
