### PR TITLE
Add array route support

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -336,6 +336,7 @@ class Router
         } elseif ($action instanceof Closure) {
             $action = [$action];
         } elseif (is_array($action)) {
+            // For this sort of syntax $api->post('login', [LoginController::class, 'login']);
             if (is_string(Arr::first($action)) && class_exists(Arr::first($action)) && count($action) == 2) {
                 $action = implode('@', $action);
                 $action = ['uses' => $action, 'controller' => $action];

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -337,6 +337,11 @@ class Router
             $action = ['uses' => $action, 'controller' => $action];
         } elseif ($action instanceof Closure) {
             $action = [$action];
+        } elseif (is_array($action)) {
+            if (is_string(Arr::first($action)) && class_exists(Arr::first($action)) && sizeof($action) == 2) {
+                $action = implode("@", $action);
+                $action = ['uses' => $action, 'controller' => $action];
+            }
         }
 
         $action = $this->mergeLastGroupAttributes($action);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -3,21 +3,21 @@
 namespace Dingo\Api\Routing;
 
 use Closure;
-use Exception;
-use RuntimeException;
+use Dingo\Api\Contract\Debug\ExceptionHandler;
+use Dingo\Api\Contract\Routing\Adapter;
+use Dingo\Api\Http\InternalRequest;
 use Dingo\Api\Http\Request;
+use Dingo\Api\Http\Response;
+use Exception;
+use Illuminate\Container\Container;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response as IlluminateResponse;
+use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Dingo\Api\Http\Response;
-use Illuminate\Http\JsonResponse;
-use Dingo\Api\Http\InternalRequest;
-use Illuminate\Container\Container;
-use Dingo\Api\Contract\Routing\Adapter;
-use Dingo\Api\Contract\Debug\ExceptionHandler;
-use Illuminate\Routing\Route as IlluminateRoute;
-use Illuminate\Http\Response as IlluminateResponse;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Router
 {
@@ -338,8 +338,8 @@ class Router
         } elseif ($action instanceof Closure) {
             $action = [$action];
         } elseif (is_array($action)) {
-            if (is_string(Arr::first($action)) && class_exists(Arr::first($action)) && sizeof($action) == 2) {
-                $action = implode("@", $action);
+            if (is_string(Arr::first($action)) && class_exists(Arr::first($action)) && count($action) == 2) {
+                $action = implode('@', $action);
                 $action = ['uses' => $action, 'controller' => $action];
             }
         }


### PR DESCRIPTION
To have more readable codes, small changes have been done. In Route, Controller names are given as arrays.

Example
```php
use App\Api\V1\Controllers\LoginController;
$api->post('login', [LoginController::class, 'login']);
```