### PR TITLE
Add Route::patterns() while app is beeing bootstrapped and not after

### DIFF
--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -2,12 +2,12 @@
 
 namespace Dingo\Api\Routing\Adapter;
 
+use Dingo\Api\Contract\Routing\Adapter;
+use Dingo\Api\Exception\UnknownVersionException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
-use Illuminate\Routing\Router;
-use Dingo\Api\Contract\Routing\Adapter;
 use Illuminate\Routing\RouteCollection;
-use Dingo\Api\Exception\UnknownVersionException;
+use Illuminate\Routing\Router;
 
 class Laravel implements Adapter
 {

--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -147,6 +147,9 @@ class Laravel implements Adapter
     {
         $this->createRouteCollections($versions);
 
+        // Add where-patterns from original laravel router
+        $action['where'] = array_merge($this->router->getPatterns(), $action['where'] ?? []);
+
         $route = new Route($methods, $uri, $action);
         $route->where($action['where']);
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -14,9 +14,7 @@ use Dingo\Api\Http\InternalRequest;
 use Illuminate\Container\Container;
 use Dingo\Api\Contract\Routing\Adapter;
 use Dingo\Api\Contract\Debug\ExceptionHandler;
-use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Http\Response as IlluminateResponse;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
 class Router
@@ -624,17 +622,6 @@ class Router
             return;
         }
 
-        // We need to recompile the route, adding the where clause (for pattern restrictions) and check again
-        if (is_object($route) && $route instanceof IlluminateRoute) {
-            $route->compiled = false;
-            $this->addWhereClausesToRoute($route);
-
-            // If the matching fails, it would be due to a parameter format validation check fail
-            if (! $route->matches($this->container['request'])) {
-                throw new NotFoundHttpException('Not Found!');
-            }
-        }
-
         return $this->currentRoute = $this->createRoute($route);
     }
 
@@ -856,23 +843,5 @@ class Router
     public function currentRouteUses($action)
     {
         return $this->currentRouteAction() == $action;
-    }
-
-    /**
-     * Add the necessary where clauses to the route based on its initial registration.
-     *
-     * @param  \Illuminate\Routing\Route  $route
-     *
-     * @return \Illuminate\Routing\Route
-     */
-    protected function addWhereClausesToRoute($route)
-    {
-        $patterns = app()->make(\Illuminate\Routing\Router::class)->getPatterns();
-
-        $route->where(array_merge(
-            $patterns, $route->getAction()['where'] ?? []
-        ));
-
-        return $route;
     }
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -3,18 +3,18 @@
 namespace Dingo\Api\Routing;
 
 use Closure;
-use Exception;
-use RuntimeException;
+use Dingo\Api\Contract\Debug\ExceptionHandler;
+use Dingo\Api\Contract\Routing\Adapter;
+use Dingo\Api\Http\InternalRequest;
 use Dingo\Api\Http\Request;
+use Dingo\Api\Http\Response;
+use Exception;
+use Illuminate\Container\Container;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response as IlluminateResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Dingo\Api\Http\Response;
-use Illuminate\Http\JsonResponse;
-use Dingo\Api\Http\InternalRequest;
-use Illuminate\Container\Container;
-use Dingo\Api\Contract\Routing\Adapter;
-use Dingo\Api\Contract\Debug\ExceptionHandler;
-use Illuminate\Http\Response as IlluminateResponse;
+use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
 class Router


### PR DESCRIPTION
In my concrete scenario I was not able to separate my handlers based on the routes with different patterns. This PR allows us to handle it properly for the LaravelAdapter.

The following examples are working now properly:

```
$api->get('/entity/{uuid}', GetEntityByUuid::class)
$api->get('/entity/{slug}', GetEntityBySlug::class)
$api->get('/entity/{customIdentifier}', GetEntityByCustomIdentifier::class)
```