### PR TITLE
Refresh RouteCollection before dispatching to the route actions

### DIFF
--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -2,12 +2,12 @@
 
 namespace Dingo\Api\Routing\Adapter;
 
+use Dingo\Api\Contract\Routing\Adapter;
+use Dingo\Api\Exception\UnknownVersionException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
-use Illuminate\Routing\Router;
-use Dingo\Api\Contract\Routing\Adapter;
 use Illuminate\Routing\RouteCollection;
-use Dingo\Api\Exception\UnknownVersionException;
+use Illuminate\Routing\Router;
 
 class Laravel implements Adapter
 {

--- a/src/Routing/Adapter/Laravel.php
+++ b/src/Routing/Adapter/Laravel.php
@@ -111,6 +111,9 @@ class Laravel implements Adapter
             foreach ($this->oldRoutes as $route) {
                 $this->mergedRoutes[$version]->add($route);
             }
+
+            $this->mergedRoutes[$version]->refreshNameLookups();
+            $this->mergedRoutes[$version]->refreshActionLookups();
         }
 
         return $this->mergedRoutes[$version];


### PR DESCRIPTION
After merging RouteCollection we should ensure that we update the internal `actionList` and `nameList`. This allows us to use the internal lookups by name which is used by the `UrlGenerator->route()` member function aka `route()` helper function.

Resolves #1695 