### PR TITLE
Fix http/https only detection

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -511,8 +511,8 @@ class Route extends \Illuminate\Routing\Route
      */
     public function httpOnly()
     {
-        return in_array('https', $this->action, true)
-            || (array_key_exists('https', $this->action) && $this->action['https']);
+        return in_array('http', $this->action, true)
+            || (array_key_exists('http', $this->action) && $this->action['http']);
     }
 
     /**
@@ -532,7 +532,8 @@ class Route extends \Illuminate\Routing\Route
      */
     public function secure()
     {
-        return in_array('https', $this->action, true);
+        return in_array('https', $this->action, true)
+            || (array_key_exists('https', $this->action) && $this->action['https']);
     }
 
     /**


### PR DESCRIPTION
This was a mistake that the httpsOnly logic was added to the http method. This is a fix for the breaking change in #1655 
