### PR TITLE
Enable default response transformation with bound transformers

### DIFF
--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -112,8 +112,6 @@ class Factory
             $binding = $this->transformer->getBinding($collection);
         }
 
-        $binding = $this->transformer->register($class, $transformer, $parameters, $after);
-
         return new Response($collection, 200, [], $binding);
     }
 

--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -106,7 +106,7 @@ class Factory
             $parameters = [];
         }
 
-        if($transformer !== null) {
+        if ($transformer !== null) {
             $binding = $this->transformer->register($class, $transformer, $parameters, $after);
         } else {
             $binding = $this->transformer->getBinding($collection);
@@ -136,7 +136,7 @@ class Factory
             $parameters = [];
         }
 
-        if($transformer !== null) {
+        if ($transformer !== null) {
             $binding = $this->transformer->register($class, $transformer, $parameters, $after);
         } else {
             $binding = $this->transformer->getBinding($item);
@@ -163,7 +163,7 @@ class Factory
             $class = get_class($paginator->first());
         }
 
-        if($transformer !== null) {
+        if ($transformer !== null) {
             $binding = $this->transformer->register($class, $transformer, $parameters, $after);
         } else {
             $binding = $this->transformer->getBinding($paginator->first());

--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -93,7 +93,7 @@ class Factory
      *
      * @return \Dingo\Api\Http\Response
      */
-    public function collection(Collection $collection, $transformer, $parameters = [], Closure $after = null)
+    public function collection(Collection $collection, $transformer = null, $parameters = [], Closure $after = null)
     {
         if ($collection->isEmpty()) {
             $class = get_class($collection);
@@ -104,6 +104,12 @@ class Factory
         if ($parameters instanceof \Closure) {
             $after = $parameters;
             $parameters = [];
+        }
+
+        if($transformer !== null) {
+            $binding = $this->transformer->register($class, $transformer, $parameters, $after);
+        } else {
+            $binding = $this->transformer->getBinding($collection);
         }
 
         $binding = $this->transformer->register($class, $transformer, $parameters, $after);
@@ -130,7 +136,11 @@ class Factory
             $parameters = [];
         }
 
-        $binding = $this->transformer->register($class, $transformer, $parameters, $after);
+        if($transformer !== null) {
+            $binding = $this->transformer->register($class, $transformer, $parameters, $after);
+        } else {
+            $binding = $this->transformer->getBinding($item);
+        }
 
         return new Response($item, 200, [], $binding);
     }
@@ -153,7 +163,11 @@ class Factory
             $class = get_class($paginator->first());
         }
 
-        $binding = $this->transformer->register($class, $transformer, $parameters, $after);
+        if($transformer !== null) {
+            $binding = $this->transformer->register($class, $transformer, $parameters, $after);
+        } else {
+            $binding = $this->transformer->getBinding($paginator->first());
+        }
 
         return new Response($paginator, 200, [], $binding);
     }

--- a/src/Transformer/Factory.php
+++ b/src/Transformer/Factory.php
@@ -110,7 +110,7 @@ class Factory
      *
      * @return \Dingo\Api\Transformer\Binding
      */
-    protected function getBinding($class)
+    public function getBinding($class)
     {
         if ($this->isCollection($class) && ! $class->isEmpty()) {
             return $this->getBindingFromCollection($class);


### PR DESCRIPTION
Using `$this->response->paginator` or `$this->response->collection` currently requires user to specify transformer binding which may already be registered according to the documentation.

This enhancement enables dingo to use the default resolution method to resolve and return transformed data.