### PR TITLE
Deal with bad actors who throw http exceptions with invalid codes

### DIFF
--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -203,11 +203,23 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
      */
     protected function getStatusCode(Throwable $exception)
     {
+        $statusCode = null;
+
         if ($exception instanceof ValidationException) {
-            return $exception->status;
+            $statusCode = $exception->status;
+        } else if ($exception instanceof HttpExceptionInterface) {
+            $statusCode = $exception->getStatusCode();
+        } else {
+            // By default throw 500
+            $statusCode = 500;
         }
 
-        return $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
+        // Be extra defensive
+        if ($statusCode < 100 || $statusCode > 500) {
+            $statusCode = 500;
+        }
+
+        return $statusCode;
     }
 
     /**

--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -183,7 +183,7 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
 
         $response = $this->newResponseArray();
 
-        array_walk_recursive($response, function (&$value, $key) use ($exception, $replacements) {
+        array_walk_recursive($response, function (&$value, $key) use ($replacements) {
             if (Str::startsWith($value, ':') && isset($replacements[$value])) {
                 $value = $replacements[$value];
             }
@@ -207,7 +207,7 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
 
         if ($exception instanceof ValidationException) {
             $statusCode = $exception->status;
-        } else if ($exception instanceof HttpExceptionInterface) {
+        } elseif ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
         } else {
             // By default throw 500


### PR DESCRIPTION
This deals with very unusual circumstances, for example when something throws an HTTP exception with a code of "0" or other invalid codes. In theory, this should not happen, but in practice anything is possible.