### PR TITLE
Allow versions above php 7 for php 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "jason.lewis1991@gmail.com"
     }],
     "require": {
-        "php": "^7.2.5",
+        "php": ">=7.2.5",
         "dingo/blueprint": "^0.4",
         "illuminate/routing": "^7.0|^8.0",
         "illuminate/support": "^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "jason.lewis1991@gmail.com"
     }],
     "require": {
-        "php": ">=7.2.5",
+        "php": "^7.2.5|^8.0",
         "dingo/blueprint": "^0.4",
         "illuminate/routing": "^7.0|^8.0",
         "illuminate/support": "^7.0|^8.0",


### PR DESCRIPTION
Currently it is not possible to install while using php 8

```bash
Problem 1
    - dingo/api v3.0.5 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - dingo/api v3.0.4 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - dingo/api v3.0.3 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - dingo/api v3.0.2 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - dingo/api v3.0.1 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - dingo/api v3.0.0 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - dingo/api v3.0.4 requires php ^7.2.5 -> your PHP version (8.0.0) does not satisfy that requirement.
    - Installation request for dingo/api ^3.0 -> satisfiable by dingo/api[v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5].
```