### PR TITLE
Fix php artisan api:routes

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -850,4 +850,14 @@ class Router
     {
         return $this->currentRouteAction() == $action;
     }
+
+    /**
+     * Flush the router's middleware groups.
+     *
+     * @return $this
+     */
+    public function flushMiddlewareGroups()
+    {
+        return $this;
+    }
 }


### PR DESCRIPTION
This fix deals with the error reported on the bug #1770, is caused by a function added on https://github.com/laravel/framework/commit/d9e28dcb1f4a5638b33829d919bd7417321ab39e, the `flushMiddlewareGroups` function was added to be compliant with `Foundation/Console/RouteListCommand.php` `handle` function.