### PR TITLE
Feat: PHP8.0.8 threw an exception

### DIFF
--- a/src/Http/RateLimit/Handler.php
+++ b/src/Http/RateLimit/Handler.php
@@ -107,7 +107,7 @@ class Handler
         // limiting will not be imposed for the request.
         } else {
             $this->throttle = $this->getMatchingThrottles()->sort(function ($a, $b) {
-                return $a->getLimit() < $b->getLimit();
+                return $a->getLimit() - $b->getLimit();
             })->first();
         }
 


### PR DESCRIPTION
"uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero"