### PR TITLE
Add #[ReturnTypeWillChange] to suppress errors and deprecation notices

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -104,6 +104,8 @@ class RouteCollection implements Countable, IteratorAggregate
      *
      * @return \ArrayIterator
      */
+    
+    #[\ReturnTypeWillChange] 
     public function getIterator()
     {
         return new ArrayIterator($this->getRoutes());
@@ -114,6 +116,8 @@ class RouteCollection implements Countable, IteratorAggregate
      *
      * @return int
      */
+    
+    #[\ReturnTypeWillChange] 
     public function count()
     {
         return count($this->getRoutes());


### PR DESCRIPTION
Return type of Dingo\Api\Routing\RouteCollection::count() isn't compatible with Countable::count()

On **PHP <var>7.4 >=</var>**
```console
dingo/api/src/Routing/RouteCollection.php on line 9

   Symfony\Component\ErrorHandler\Error\FatalError 

  During inheritance of Countable: Uncaught ErrorException: Return type of Dingo\Api\Routing\RouteCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```
Same on getIterator()